### PR TITLE
Issue #16. Adding basic getters for dispute, round and account, including tests.

### DIFF
--- a/contracts/Court.sol
+++ b/contracts/Court.sol
@@ -844,8 +844,7 @@ contract Court is ERC900, ApproveAndCallFallBack {
         view
         returns (uint8 winningRuling, uint64 draftTerm, uint64 jurorNumber, address triggeredBy, bool settledPenalties, uint256 slashedTokens)
     {
-        Dispute storage dispute = disputes[_disputeId];
-        AdjudicationRound storage round = dispute.rounds[_roundId];
+        AdjudicationRound storage round = disputes[_disputeId].rounds[_roundId];
         return (round.winningRuling, round.draftTerm, round.jurorNumber, round.triggeredBy, round.settledPenalties, round.slashedTokens);
     }
 

--- a/contracts/Court.sol
+++ b/contracts/Court.sol
@@ -834,6 +834,30 @@ contract Court is ERC900, ApproveAndCallFallBack {
         return account.balances[jurorToken].sub(account.atStakeTokens);
     }
 
+    function getDispute(uint256 _disputeId) external view returns (address subject, uint8 possibleRulings, DisputeState state) {
+        Dispute storage dispute = disputes[_disputeId];
+        return (dispute.subject, dispute.possibleRulings, dispute.state);
+    }
+
+    function getAdjudicationRound(uint256 _disputeId, uint256 _roundId)
+        external
+        view
+        returns (uint8 winningRuling, uint64 draftTerm, uint64 jurorNumber, address triggeredBy, bool settledPenalties, uint256 slashedTokens)
+    {
+        Dispute storage dispute = disputes[_disputeId];
+        AdjudicationRound storage round = dispute.rounds[_roundId];
+        return (round.winningRuling, round.draftTerm, round.jurorNumber, round.triggeredBy, round.settledPenalties, round.slashedTokens);
+    }
+
+    function getAccount(address _accountAddress)
+        external
+        view
+        returns (AccountState state, uint64 fromTerm, uint64 toTerm, uint256 atStakeTokens, uint256 sumTreeId)
+    {
+        Account storage account = accounts[_accountAddress];
+        return (account.state, account.fromTerm, account.toTerm, account.atStakeTokens, account.sumTreeId);
+    }
+
     function _editUpdate(AccountUpdate storage update, uint256 _delta, bool _positive) internal {
         (update.delta, update.positive) = _signedSum(update.delta, update.positive, _delta, _positive);
     }

--- a/test/court-disputes.js
+++ b/test/court-disputes.js
@@ -141,30 +141,30 @@ contract('Court: Disputes', ([ poor, rich, governor, juror1, juror2, juror3, arb
       const firstRoundId = 0
 
       beforeEach(async () => {
-          await assertLogs(this.court.createDispute(arbitrable, rulings, jurors, term, { from: poor }), NEW_DISPUTE_EVENT)
+        await assertLogs(this.court.createDispute(arbitrable, rulings, jurors, term, { from: poor }), NEW_DISPUTE_EVENT)
       })
 
       it('gets the correct dispute details', async () => {
-          const dispute = await this.court.getDispute(disputeId)
+        const dispute = await this.court.getDispute(disputeId)
 
-          assert.strictEqual(dispute[0], arbitrable, 'COURT_INCORRECT_DISPUTE_SUBJECT')
-          assertEqualBN(dispute[1], rulings, 'COURT_INCORRECT_DISPUTE_RULINGS')
-          assertEqualBN(dispute[2], 0, 'COURT_INCORRECT_DISPUTE_STATE')
+        assert.strictEqual(dispute[0], arbitrable, 'COURT_INCORRECT_DISPUTE_SUBJECT')
+        assertEqualBN(dispute[1], rulings, 'COURT_INCORRECT_DISPUTE_RULINGS')
+        assertEqualBN(dispute[2], 0, 'COURT_INCORRECT_DISPUTE_STATE')
       })
 
       it('gets the correct dispute round details', async () => {
-          const expectedWinningRuling = 0
-          const exepctedRoundPenalties = false
-          const expectedRoundSlashing = 0
+        const expectedWinningRuling = 0
+        const exepctedRoundPenalties = false
+        const expectedRoundSlashing = 0
 
-          const round = await this.court.getAdjudicationRound(disputeId, firstRoundId)
+        const round = await this.court.getAdjudicationRound(disputeId, firstRoundId)
 
-          assertEqualBN(round[0], expectedWinningRuling, 'COURT_INCORRECT_ROUND_RULING')
-          assertEqualBN(await round[1], term, 'COURT_INCORRECT_ROUND_TERM')
-          assertEqualBN(await round[2], jurors, 'COURT_INCORRECT_ROUND_JURORS')
-          assert.strictEqual(round[3], poor, 'COURT_INCORRECT_ROUND_ACCOUNT')
-          assert.strictEqual(round[4], exepctedRoundPenalties, 'COURT_INCORRECT_ROUND_PENALTIES')
-          assertEqualBN(round[5], expectedRoundSlashing, 'COURT_INCORRECT_ROUND_SLASHING')
+        assertEqualBN(round[0], expectedWinningRuling, 'COURT_INCORRECT_ROUND_RULING')
+        assertEqualBN(await round[1], term, 'COURT_INCORRECT_ROUND_TERM')
+        assertEqualBN(await round[2], jurors, 'COURT_INCORRECT_ROUND_JURORS')
+        assert.strictEqual(round[3], poor, 'COURT_INCORRECT_ROUND_ACCOUNT')
+        assert.strictEqual(round[4], exepctedRoundPenalties, 'COURT_INCORRECT_ROUND_PENALTIES')
+        assertEqualBN(round[5], expectedRoundSlashing, 'COURT_INCORRECT_ROUND_SLASHING')
       })
 
 

--- a/test/court-disputes.js
+++ b/test/court-disputes.js
@@ -141,8 +141,32 @@ contract('Court: Disputes', ([ poor, rich, governor, juror1, juror2, juror3, arb
       const firstRoundId = 0
 
       beforeEach(async () => {
-        await assertLogs(this.court.createDispute(arbitrable, rulings, jurors, term), NEW_DISPUTE_EVENT)
+          await assertLogs(this.court.createDispute(arbitrable, rulings, jurors, term, { from: poor }), NEW_DISPUTE_EVENT)
       })
+
+      it('gets the correct dispute details', async () => {
+          const dispute = await this.court.getDispute(disputeId)
+
+          assert.strictEqual(dispute[0], arbitrable, 'COURT_INCORRECT_DISPUTE_SUBJECT')
+          assertEqualBN(dispute[1], rulings, 'COURT_INCORRECT_DISPUTE_RULINGS')
+          assertEqualBN(dispute[2], 0, 'COURT_INCORRECT_DISPUTE_STATE')
+      })
+
+      it('gets the correct dispute round details', async () => {
+          const expectedWinningRuling = 0
+          const exepctedRoundPenalties = false
+          const expectedRoundSlashing = 0
+
+          const round = await this.court.getAdjudicationRound(disputeId, firstRoundId)
+
+          assertEqualBN(round[0], expectedWinningRuling, 'COURT_INCORRECT_ROUND_RULING')
+          assertEqualBN(await round[1], term, 'COURT_INCORRECT_ROUND_TERM')
+          assertEqualBN(await round[2], jurors, 'COURT_INCORRECT_ROUND_JURORS')
+          assert.strictEqual(round[3], poor, 'COURT_INCORRECT_ROUND_ACCOUNT')
+          assert.strictEqual(round[4], exepctedRoundPenalties, 'COURT_INCORRECT_ROUND_PENALTIES')
+          assertEqualBN(round[5], expectedRoundSlashing, 'COURT_INCORRECT_ROUND_SLASHING')
+      })
+
 
       it('fails to draft outside of the draft term', async () => {
         await passTerms(1) // term = 2

--- a/test/court-lifecycle.js
+++ b/test/court-lifecycle.js
@@ -154,11 +154,11 @@ contract('Court: Lifecycle', ([ poor, rich, governor, juror1, juror2 ]) => {
         actualSumTreeId
       ] = await this.court.getAccount(rich)
 
-      assertEqualBN(actualState, ACCOUNT_STATE.JUROR, 'incorrect account state')
-      assertEqualBN(actualFromTerm, expectedFromTerm, 'incorrect account from term')
-      assertEqualBN(actualToTerm, expectedToTerm, 'incorrect account to term')
-      assertEqualBN(actualAtStake, expectedAtStake, 'incorrect account at stake')
-      assertEqualBN(actualSumTreeId, expectedSumTreeId, 'incorrect account sum tree id')
+      await assertEqualBN(actualState, ACCOUNT_STATE.JUROR, 'incorrect account state')
+      await assertEqualBN(actualFromTerm, expectedFromTerm, 'incorrect account from term')
+      await assertEqualBN(actualToTerm, expectedToTerm, 'incorrect account to term')
+      await assertEqualBN(actualAtStake, expectedAtStake, 'incorrect account at stake')
+      await assertEqualBN(actualSumTreeId, expectedSumTreeId, 'incorrect account sum tree id')
     })
 
     it('reverts if activating balance is below dust', async () => {

--- a/test/court-lifecycle.js
+++ b/test/court-lifecycle.js
@@ -103,6 +103,13 @@ contract('Court: Lifecycle', ([ poor, rich, governor, juror1, juror2 ]) => {
   })
 
   context('before first term', () => {
+
+    const ACCOUNT_STATE = {
+      NOT_JUROR: 0,
+      JUROR: 1,
+      PAST_JUROR: 2,
+    }
+
     it('it in term #0', async () => {
       await assertEqualBN(this.court.term(), 0, 'court term #0')
     })
@@ -133,20 +140,25 @@ contract('Court: Lifecycle', ([ poor, rich, governor, juror1, juror2 ]) => {
     })
 
     it('gets the correct account details after activation', async () => {
-      const expectedAccountState = 1
       const expectedFromTerm = 1
       const expectedToTerm = 10
       const expectedAtStake = 0
       const expectedSumTreeId = 1
       await this.court.activate(expectedFromTerm, expectedToTerm, {from: rich })
 
-      const accountDetails = await this.court.getAccount(rich)
+      const [
+        actualState,
+        actualFromTerm,
+        actualToTerm,
+        actualAtStake,
+        actualSumTreeId
+      ] = await this.court.getAccount(rich)
 
-      assertEqualBN(accountDetails[0], expectedAccountState, 'COURT_INCORRECT_ACCOUNT_STATE')
-      assertEqualBN(accountDetails[1], expectedFromTerm, 'COURT_INCORRECT_ACCOUNT_FROM_TERM')
-      assertEqualBN(accountDetails[2], expectedToTerm, 'COURT_INCORRECT_ACCOUNT_TO_TERM')
-      assertEqualBN(accountDetails[3], expectedAtStake, 'COURT_INCORRECT_ACCOUNT_AT_STAKE')
-      assertEqualBN(accountDetails[4], expectedSumTreeId, 'COURT_INCORRECT_ACCOUNT_SUM_TREE_ID')
+      assertEqualBN(actualState, ACCOUNT_STATE.JUROR, 'incorrect account state')
+      assertEqualBN(actualFromTerm, expectedFromTerm, 'incorrect account from term')
+      assertEqualBN(actualToTerm, expectedToTerm, 'incorrect account to term')
+      assertEqualBN(actualAtStake, expectedAtStake, 'incorrect account at stake')
+      assertEqualBN(actualSumTreeId, expectedSumTreeId, 'incorrect account sum tree id')
     })
 
     it('reverts if activating balance is below dust', async () => {

--- a/test/court-lifecycle.js
+++ b/test/court-lifecycle.js
@@ -132,6 +132,23 @@ contract('Court: Lifecycle', ([ poor, rich, governor, juror1, juror2 ]) => {
       await assertEqualBN(this.court.mock_treeTotalSum(), richStake, 'total tree sum')
     })
 
+    it('gets the correct account details after activation', async () => {
+      const expectedAccountState = 1
+      const expectedFromTerm = 1
+      const expectedToTerm = 10
+      const expectedAtStake = 0
+      const expectedSumTreeId = 1
+      await this.court.activate(expectedFromTerm, expectedToTerm, {from: rich })
+
+      const accountDetails = await this.court.getAccount(rich)
+
+      assertEqualBN(accountDetails[0], expectedAccountState, 'COURT_INCORRECT_ACCOUNT_STATE')
+      assertEqualBN(accountDetails[1], expectedFromTerm, 'COURT_INCORRECT_ACCOUNT_FROM_TERM')
+      assertEqualBN(accountDetails[2], expectedToTerm, 'COURT_INCORRECT_ACCOUNT_TO_TERM')
+      assertEqualBN(accountDetails[3], expectedAtStake, 'COURT_INCORRECT_ACCOUNT_AT_STAKE')
+      assertEqualBN(accountDetails[4], expectedSumTreeId, 'COURT_INCORRECT_ACCOUNT_SUM_TREE_ID')
+    })
+
     it('reverts if activating balance is below dust', async () => {
       await this.court.mock_setTime(firstTermStart - 1)
       await assertRevert(this.court.activate(1, 10, { from: poor }), 'COURT_TOKENS_BELOW_MIN_STAKE')


### PR DESCRIPTION
Fixes issue #16 

This is my first PR with you guys, hoping to work on some of the other more basic issues as well. 

I added tests although I understand if they're overkill for getters in which case I can remove them.

I assumed it wouldn't be useful to expose the AdjudicationRound's `votes` and `rulingVotes` or the Account's `update` struct in separate getters as they seem like things that only need to be used internally.

I considered adding a `getUnlockedAccountBalance(address _accountAddress, address _tokenAddress)` which would return `accounts[_accountAddress].balances[_tokenAddress]` which could be used to find the values needed for the function `withdraw(ERC20 _token, uint256 _amount)`. However, I can't see any way of staking or otherwise sending tokens besides the juror token to this contract, and see there's an `unlockedBalanceOf(address _addr)` function which does the above for the juror token, so figured it's probably not useful.

Will gladly add any of the above if it's expected they could be useful though.