### PR TITLE
Appeals: implement collateral requirements and appeal confirmation

### DIFF
--- a/contracts/test/CourtMock.sol
+++ b/contracts/test/CourtMock.sol
@@ -20,7 +20,7 @@ contract CourtMock is Court {
         address _governor,
         uint64 _firstTermStartTime,
         uint256 _jurorMinStake,
-        uint64[3] _roundStateDurations,
+        uint64[4] _roundStateDurations,
         uint16 _penaltyPct
     ) Court(
         _termDuration,


### PR DESCRIPTION
For an appeal to create an adjudication round, two different parties need to put up collateral in two different periods: 

- During the `Appeal` period, someone who doesn't agree with the preliminary ruling of the Court can appeal and provide a different ruling that they think should be the outcome. 
- During the `AppealConfirm` period, someone who supports the current preliminary ruling needs put up collateral to confirm the appeal round. If an appeal is created, but not confirmed, the ruling will be immediately flipped to the ruling that the original appealer supported and considered the final ruling.

When the Court produces a final ruling, all the collateral collected from both parties is transferred to the party that appealed for the final ruling.

Pending work:

- [ ] Juror fee refunds when no juror was coherent in the triggered adjudication round
- [ ] Adapt tests (these changes made the contract go over the bytecode size limit)