### PR TITLE
Court: allow to continue draft at a later term

### DIFF
--- a/contracts/Court.sol
+++ b/contracts/Court.sol
@@ -728,7 +728,7 @@ contract Court is ERC900, ApproveAndCallFallBack, ICRVotingOwner {
         return _canPerformVotingAction(_voteId, _voter, AdjudicationState.Reveal);
     }
 
-    function _canPerformVotingAction(uint256 _voteId, address _voter, AdjudicationState _state) internal returns (uint256) {
+    function _canPerformVotingAction(uint256 _voteId, address _voter, AdjudicationState _state) internal view returns (uint256) {
         require(_voteId <= MAX_UINT32, ERROR_OVERFLOW);
         Vote storage vote = votes[uint32(_voteId)];
         uint256 disputeId = vote.disputeId;
@@ -789,12 +789,9 @@ contract Court is ERC900, ApproveAndCallFallBack, ICRVotingOwner {
         return voting.getVote(dispute.rounds[dispute.rounds.length - 1].voteId);
     }
 
-    function _checkAdjudicationState(uint256 _disputeId, uint256 _roundId, AdjudicationState _state) internal {
+    function _checkAdjudicationState(uint256 _disputeId, uint256 _roundId, AdjudicationState _state) internal view {
         Dispute storage dispute = disputes[_disputeId];
         DisputeState disputeState = dispute.state;
-        if (disputeState == DisputeState.PreDraft) {
-            draftAdjudicationRound(_disputeId);
-        }
 
         require(disputeState == DisputeState.Adjudicating, ERROR_INVALID_DISPUTE_STATE);
         require(_roundId == dispute.rounds.length - 1, ERROR_INVALID_ADJUDICATION_ROUND);

--- a/contracts/test/CourtMock.sol
+++ b/contracts/test/CourtMock.sol
@@ -102,6 +102,10 @@ contract CourtMock is Court {
         return MAX_JURORS_PER_BATCH;
     }
 
+    function getAdjudicationState(uint256 _disputeId, uint256 _roundId, uint64 _termId) public view returns (AdjudicationState) {
+        return _adjudicationStateAtTerm(_disputeId, _roundId, _termId);
+    }
+
     function _time() internal view returns (uint64) {
         return mockTime;
     }

--- a/test/court-batches.js
+++ b/test/court-batches.js
@@ -139,7 +139,7 @@ contract('Court: Batches', ([ rich, governor, arbitrable, juror1, juror2, juror3
       disputeId = getLog(receipt, NEW_DISPUTE_EVENT, 'disputeId')
       voteId = getLog(receipt, NEW_DISPUTE_EVENT, 'voteId')
       await passTerms(2) // term = 3
-
+      await this.court.mock_blockTravel(1)
     }
 
     context('hijacked', () => {
@@ -233,6 +233,7 @@ contract('Court: Batches', ([ rich, governor, arbitrable, juror1, juror2, juror3
           await checkAdjudicationState(disputeId, firstRoundId, initialTermId + termsPassed)
           await passTerms(1)
           termsPassed++
+          await this.court.mock_blockTravel(1)
         }
         assert.isTrue(await this.court.areAllJurorsDrafted.call(disputeId, firstRoundId))
         assert.isTrue(termsPassed > 1, 'draft was not split')

--- a/test/court-batches.js
+++ b/test/court-batches.js
@@ -171,7 +171,7 @@ contract('Court: Batches', ([ rich, governor, arbitrable, juror1, juror2, juror3
         }
       }
 
-      const checkAdjudicationState = async (disputeId, roundId, baseTermId) => {
+      const checkAdjudicationState = async (disputeId, roundId, initialTermId, termsPassed) => {
         const states = [
           {
             name: "Invalid",
@@ -199,7 +199,8 @@ contract('Court: Batches', ([ rich, governor, arbitrable, juror1, juror2, juror3
             offset: commitTerms + revealTerms + appealTerms
           }
         ]
-        const termId = baseTermId
+        const isDraftingOver = await this.court.areAllJurorsDrafted.call(disputeId, firstRoundId)
+        const baseTermId = isDraftingOver ? initialTermId + termsPassed : initialTermId
         for (const state of states) {
           const stateResult = (await this.court.getAdjudicationState(disputeId, roundId, baseTermId + state.offset)).toNumber()
           assert.equal(stateResult, state.state, `Wrong state for ${state.name}`)
@@ -230,7 +231,7 @@ contract('Court: Batches', ([ rich, governor, arbitrable, juror1, juror2, juror3
           callsHistory.push(callJurorsDrafted)
           totalJurorsDrafted += callJurorsDrafted
           await checkWeights(callsHistory)
-          await checkAdjudicationState(disputeId, firstRoundId, initialTermId + termsPassed)
+          await checkAdjudicationState(disputeId, firstRoundId, initialTermId, termsPassed)
           await passTerms(1)
           termsPassed++
           await this.court.mock_blockTravel(1)

--- a/test/court-disputes.js
+++ b/test/court-disputes.js
@@ -159,6 +159,7 @@ contract('Court: Disputes', ([ poor, rich, governor, juror1, juror2, juror3, arb
 
       it('fails to draft outside of the draft term', async () => {
         await passTerms(1) // term = 2
+        await this.court.mock_blockTravel(1)
         await assertRevert(this.court.draftAdjudicationRound(disputeId), 'COURT_NOT_DRAFT_TERM')
       })
 
@@ -172,6 +173,7 @@ contract('Court: Disputes', ([ poor, rich, governor, juror1, juror2, juror3, arb
 
         beforeEach(async () => {
           await passTerms(2) // term = 3
+          await this.court.mock_blockTravel(1)
           await assertLogs(this.court.draftAdjudicationRound(disputeId), JUROR_DRAFTED_EVENT, DISPUTE_STATE_CHANGED_EVENT)
         })
 
@@ -302,6 +304,7 @@ contract('Court: Disputes', ([ poor, rich, governor, juror1, juror2, juror3, arb
 
               it('drafts jurors', async () => {
                 await passTerms(1) // term = 6
+                await this.court.mock_blockTravel(1)
                 await assertLogs(this.court.draftAdjudicationRound(disputeId), JUROR_DRAFTED_EVENT, DISPUTE_STATE_CHANGED_EVENT)
               })
             })

--- a/test/court-disputes.js
+++ b/test/court-disputes.js
@@ -160,8 +160,6 @@ contract('Court: Disputes', ([ poor, rich, governor, juror1, juror2, juror3, arb
       it('fails to draft outside of the draft term', async () => {
         await passTerms(1) // term = 2
         await assertRevert(this.court.draftAdjudicationRound(disputeId), 'COURT_NOT_DRAFT_TERM')
-        await passTerms(2) // term = 4
-        await assertRevert(this.court.draftAdjudicationRound(disputeId), 'COURT_NOT_DRAFT_TERM')
       })
 
       context('on juror draft (hijacked)', () => {


### PR DESCRIPTION
In case not all batches were fullfilled.
Closes issue #14.

I considered two approaches:

1. Try to reset all previous draft state, and start again from scratch in a later term.

Pros:
- Kind of cleaner.

Cons:
- Waste of gas
- More likely to get stuck again
- Users could try to game the system by not finishing the draft and waiting for another term with better randomeness for their interests.

2. Reuse previously drafted jurors and continue adding more in a later term, which will be considered the starting point for round state intervals.

Pros:
- More gas efficient.
- Fixed randomeness for ever for that round
- More likely to finish the draft

Cons:
- If court config changes in between it may be a little bit confusing
