### PR TITLE
Court: Make max number of appeal rounds configurable

### DIFF
--- a/contracts/test/CourtMock.sol
+++ b/contracts/test/CourtMock.sol
@@ -20,6 +20,7 @@ contract CourtMock is Court {
         uint256 _jurorMinStake,
         uint64[3] _roundStateDurations,
         uint16[2] _pcts,
+        uint32 _maxRegularAppealRounds,
         uint256[5] _subscriptionParams // _periodDuration, _feeAmount, _prePaymentPeriods, _latePaymentPenaltyPct, _governorSharePct
     )
         Court(
@@ -35,7 +36,7 @@ contract CourtMock is Court {
             _jurorMinStake,
             _roundStateDurations,
             _pcts,
-            _subscriptionParams
+            _maxRegularAppealRounds,_subscriptionParams
         )
         public
     {}
@@ -68,10 +69,6 @@ contract CourtMock is Court {
 
     function getMaxJurorsPerDraftBatch() public pure returns (uint256) {
         return MAX_JURORS_PER_DRAFT_BATCH;
-    }
-
-    function getMaxRegularAppealRounds() public pure returns (uint256) {
-        return MAX_REGULAR_APPEAL_ROUNDS;
     }
 
     function getAppealStepFactor() public pure returns (uint64) {

--- a/test/court-batches.js
+++ b/test/court-batches.js
@@ -90,6 +90,7 @@ contract('Court: Batches', ([ rich, governor, arbitrable, juror1, juror2, juror3
       jurorMinStake,
       [ commitTerms, appealTerms, revealTerms ],
       [ penaltyPct, finalRoundReduction ],
+      4,
       [ 0, 0, 0, 0, 0 ]
     )
 

--- a/test/court-disputes.js
+++ b/test/court-disputes.js
@@ -52,7 +52,7 @@ contract('Court: Disputes', ([ poor, rich, governor, juror1, juror2, juror3, oth
   const NO_DATA = ''
   const ZERO_ADDRESS = '0x' + '00'.repeat(20)
   const MAX_UINT256 = new web3.BigNumber(2).pow(256).sub(1)
-  
+
   const termDuration = 10
   const firstTermStart = 10
   const jurorMinStake = 400
@@ -125,6 +125,7 @@ contract('Court: Disputes', ([ poor, rich, governor, juror1, juror2, juror3, oth
       jurorMinStake,
       [ commitTerms, appealTerms, revealTerms ],
       [ penaltyPct, finalRoundReduction ],
+      4,
       [ 0, 0, 0, 0, 0 ]
     )
 

--- a/test/court-init.js
+++ b/test/court-init.js
@@ -68,6 +68,7 @@ contract('Court: init', ([ governor ]) => {
         jurorMinStake,
         [ commitTerms, appealTerms, revealTerms ],
         [ penaltyPct, finalRoundReduction ],
+        4,
         [ 0, 0, 0, 0, 0 ]
       ),
       ERROR_WRONG_PENALTY_PCT

--- a/test/court-lifecycle.js
+++ b/test/court-lifecycle.js
@@ -34,7 +34,7 @@ contract('Court: Lifecycle', ([ poor, rich, governor, juror1, juror2 ]) => {
   const NO_DATA = ''
   const ZERO_ADDRESS = '0x' + '00'.repeat(20)
   const MAX_UINT64 = 2**64 - 1
-  
+
   const termDuration = 10
   const firstTermStart = 15
   const jurorMinStake = 100
@@ -86,6 +86,7 @@ contract('Court: Lifecycle', ([ poor, rich, governor, juror1, juror2 ]) => {
       jurorMinStake,
       [ commitTerms, appealTerms, revealTerms ],
       [ penaltyPct, finalRoundReduction ],
+      4,
       [ 0, 0, 0, 0, 0 ]
     )
 


### PR DESCRIPTION
Fixes #55.

:warning: It increments bytecode by ~800, surpassing EIP-170 value again.