### PR TITLE
Fix bug in canCommit function for final round

### DIFF
--- a/contracts/test/CourtStakingMock.sol
+++ b/contracts/test/CourtStakingMock.sol
@@ -19,6 +19,10 @@ contract CourtStakingMock is CourtStaking {
         treeSearchHijacked = true;
     }
 
+    function updateTreeBalance(address _juror, uint64 _termId, uint256 _delta, bool _positive) external {
+        sumTree.update(accounts[_juror].sumTreeId, _termId, _delta, _positive);
+    }
+
     function _treeSearch(uint256[7] _params)
         internal
         view

--- a/test/court-batches.js
+++ b/test/court-batches.js
@@ -45,7 +45,7 @@ contract('Court: Batches', ([ rich, governor, arbitrable, juror1, juror2, juror3
   const commitTerms = 1
   const revealTerms = 1
   const appealTerms = 1
-  const penaltyPct = 100 // 100‱ = 1%
+  const penaltyPct = 1000 // 100‱ = 1%
   const finalRoundReduction = 3300 // 100‱ = 1%
 
   const initialBalance = 1e6

--- a/test/court-init.js
+++ b/test/court-init.js
@@ -1,0 +1,76 @@
+const { assertRevert } = require('@aragon/os/test/helpers/assertThrow')
+
+const TokenFactory = artifacts.require('TokenFactory')
+const CourtMock = artifacts.require('CourtMock')
+const CourtStakingMock = artifacts.require('CourtStakingMock')
+const CRVoting = artifacts.require('CRVoting')
+const SumTree = artifacts.require('HexSumTreeWrapper')
+const Subscriptions = artifacts.require('SubscriptionsMock')
+
+const MINIME = 'MiniMeToken'
+
+const getLog = (receipt, logName, argName) => {
+  const log = receipt.logs.find(({ event }) => event == logName)
+  return log ? log.args[argName] : null
+}
+
+const deployedContract = async (receiptPromise, name) =>
+      artifacts.require(name).at(getLog(await receiptPromise, 'Deployed', 'addr'))
+
+const assertEqualBN = async (actualPromise, expected, message) =>
+      assert.equal((await actualPromise).toNumber(), expected, message)
+
+contract('Court: init', ([ governor ]) => {
+  const ZERO_ADDRESS = '0x' + '00'.repeat(20)
+
+  const initialBalance = 1e6
+
+  const ERROR_WRONG_PENALTY_PCT = 'CTBAD_PENALTY'
+
+  before(async () => {
+    this.tokenFactory = await TokenFactory.new()
+  })
+
+  beforeEach(async () => {
+    // Mints 1,000,000 tokens for sender
+    this.anj = await deployedContract(this.tokenFactory.newToken('ANJ', initialBalance), MINIME)
+
+    this.staking = await CourtStakingMock.new()
+    this.voting = await CRVoting.new()
+    this.sumTree = await SumTree.new()
+    this.subscriptions = await Subscriptions.new()
+    await this.subscriptions.setUpToDate(true)
+  })
+
+  it('fails to deploy if penaltyPct is too low compared to jurorMinStake', async () => {
+    const termDuration = 10
+    const firstTermStart = 10
+    const startBlock = 1000
+    const commitTerms = 1
+    const revealTerms = 1
+    const appealTerms = 1
+    const finalRoundReduction = 3300 // 100‱ = 1%
+
+    const jurorMinStake = 200
+    const penaltyPct = 10 // 100‱ = 1%
+
+    await assertRevert(
+      CourtMock.new(
+        termDuration,
+        [ this.anj.address, ZERO_ADDRESS ], // no fees
+        this.staking.address,
+        this.voting.address,
+        this.sumTree.address,
+        this.subscriptions.address,
+        [ 0, 0, 0, 0 ],
+        governor,
+        firstTermStart,
+        jurorMinStake,
+        [ commitTerms, appealTerms, revealTerms ],
+        [ penaltyPct, finalRoundReduction ],
+        [ 0, 0, 0, 0, 0 ]
+      ),
+      ERROR_WRONG_PENALTY_PCT
+    )
+  })
+})

--- a/test/court-staking.js
+++ b/test/court-staking.js
@@ -35,7 +35,7 @@ contract('Court: Staking', ([ pleb, rich, governor ]) => {
   const commitTerms = 1
   const revealTerms = 1
   const appealTerms = 1
-  const penaltyPct = 100 // 100‱ = 1%
+  const penaltyPct = 1000 // 100‱ = 1%
   const finalRoundReduction = 3300 // 100‱ = 1%
 
   const SALT = soliditySha3('passw0rd')


### PR DESCRIPTION
Now we make sure that jurors have at least min stake to be able to
vote in final rounds and that potential weighted penalty to be slashed
is not zero.

Closes #70 

Notice: change base to `development` once #64 has been merged.