### PR TITLE
CourtStaking: Fix settleRegularRound bug

### DIFF
--- a/test/court-batches.js
+++ b/test/court-batches.js
@@ -323,7 +323,7 @@ contract('Court: Batches', ([ rich, governor, arbitrable, juror1, juror2, juror3
     })
 
     it('settles in 2 batches', async () => {
-      const batchSize = 40
+      const batchSize = 4
       await this.court.settleRoundSlashing(disputeId, firstRoundId, batchSize)
       assert.isFalse(await this.court.areAllJurorsSettled.call(disputeId, firstRoundId))
       const receipt = await this.court.settleRoundSlashing(disputeId, firstRoundId, batchSize)


### PR DESCRIPTION
In spite of weights, drafted jurors could still be stored more than
once in round array, and thus those jurors were being slashed more
than once on settlement.

Thanks @facuspagnuolo for finding this!

Related to #22 

Final note: we may consider not grouping at all on `CourtStaking.draft` function, avoiding the use of weights there. Depending on the nature of data it may be better: if jurors are often repeated, size of arrays passed through contracts would be smaller, but if they are not, we would save `weights` array and simplify logic on one side (as right now we are checking duplicates twice, in different ways). As it would be a significant change, I'll open a separate issue for this.