### PR TITLE
Registry: Test draft and slash functions

### DIFF
--- a/contracts/JurorsRegistry.sol
+++ b/contracts/JurorsRegistry.sol
@@ -711,7 +711,7 @@ contract JurorsRegistry is Initializable, IsContract, IJurorsRegistry, ERC900, A
     * @return activeBalances List of active balances for each juror obtained based on the requested search
     */
     function _treeSearch(uint256[7] _treeSearchParams) internal view returns (uint256[] ids, uint256[] activeBalances) {
-        (ids, activeBalances) = tree.multiSortition(
+        (ids, activeBalances) = tree.batchedRandomSearch(
             bytes32(_treeSearchParams[0]),  // _termRandomness,
             _treeSearchParams[1],           // _disputeId
             uint64(_treeSearchParams[2]),   // _termId

--- a/contracts/JurorsRegistry.sol
+++ b/contracts/JurorsRegistry.sol
@@ -32,9 +32,8 @@ contract JurorsRegistry is Initializable, IsContract, IJurorsRegistry, ERC900, A
     string internal constant ERROR_CANNOT_REDUCE_DEACTIVATION_REQUEST = "JR_CANT_REDUCE_DEACTIVATION_REQ";
     string internal constant ERROR_TOKEN_TRANSFER_FAILED = "JR_TOKEN_TRANSFER_FAILED";
     string internal constant ERROR_TOKEN_APPROVE_NOT_ALLOWED = "JR_TOKEN_APPROVE_NOT_ALLOWED";
-    string internal constant ERROR_SORTITION_LENGTHS_MISMATCH = "JR_SORTITION_LENGTHS_MISMATCH";
 
-    uint256 internal constant PCT_BASE = 10000; // %
+    uint256 internal constant PCT_BASE = 10000; // ‱ = 1 / 10,000
     address internal constant BURN_ACCOUNT = 0xdead;
 
     /**
@@ -216,37 +215,35 @@ contract JurorsRegistry is Initializable, IsContract, IJurorsRegistry, ERC900, A
     *
     * @return jurors List of jurors selected for the draft
     * @return weights List of weights corresponding to each juror
-    * @return jurorsLength Number of jurors selected for the draft // TODO: shouldn't this be eq to jurors.length?
-    * @return filledSeats Number of seats filled for the draft
+    * @return outputLength Size of the list of the draft result
+    * @return selectedJurors Number of seats selected for the draft
     */
     function draft(uint256[7] _params) external onlyOwner
-        returns (address[] jurors, uint64[] weights, uint256 jurorsLength, uint64 filledSeats)
+        returns (address[] jurors, uint64[] weights, uint256 outputLength, uint64 selectedJurors)
     {
-        uint256 roundSeatsLeft = _params[4]; // _jurorsRequested
-        jurors = new address[](roundSeatsLeft);
-        weights = new uint64[](roundSeatsLeft);
-        filledSeats = uint64(_params[3]); // _filledSeats
+        uint256 batchRequestedJurors = _params[4];
+        jurors = new address[](batchRequestedJurors);
+        weights = new uint64[](batchRequestedJurors);
+        selectedJurors = uint64(_params[3]);
 
-        // to add "randomness" to sortition call in order to avoid getting stuck by
-        // getting the same overleveraged juror over and over
-        uint256 sortitionIteration = 0;
-
-        while (roundSeatsLeft > 0) {
+        // Jurors returned by the tree multi-sortition may not have enough unlocked active balance to be drafted. Thus,
+        // we compute several sortitions until all the requested jurors are selected. To guarantee a different set of
+        // jurors on each sortition, the iteration number will be part of the random seed to be used in the sortition.
+        // Note that this loop could end with an OOG error.
+        for (uint256 sortitionIteration = 0; batchRequestedJurors > 0; sortitionIteration++) {
             uint256[7] memory treeSearchParams = [
-                _params[0], // _randomness
-                _params[1], // _disputeId
-                _params[2], // _termId
-                filledSeats,
-                roundSeatsLeft,
-                _params[5], // _jurorNumber
+                _params[0],           // _termRandomness
+                _params[1],           // _disputeId
+                _params[2],           // _termId
+                selectedJurors,
+                batchRequestedJurors,
+                _params[5],           // _roundRequestedJurors
                 sortitionIteration
             ];
 
-            (uint256[] memory jurorIds, uint256[] memory stakes) = _treeSearch(treeSearchParams);
-            require(jurorIds.length == stakes.length, ERROR_SORTITION_LENGTHS_MISMATCH);
-            require(jurorIds.length == roundSeatsLeft, ERROR_SORTITION_LENGTHS_MISMATCH);
-
+            (uint256[] memory jurorIds, uint256[] memory activeBalances) = _treeSearch(treeSearchParams);
             for (uint256 i = 0; i < jurorIds.length; i++) {
+                // We assume the selected jurors are registered in the registry, we are not checking their addresses exist
                 address juror = jurorsAddressById[jurorIds[i]];
                 Juror storage _juror = jurorsByAddress[juror];
                 uint256 newLockedBalance = _juror.lockedBalance.add(_draftLockAmount(uint16(_params[6]))); // _penaltyPct
@@ -255,27 +252,26 @@ contract JurorsRegistry is Initializable, IsContract, IJurorsRegistry, ERC900, A
                 // otherwise. Note that there's no need to check deactivation requests since these always apply
                 // for the next term, while drafts are always computed for the current term with the active balances
                 // which always remain constant for the current term.
-                if (stakes[i] >= newLockedBalance) {
+                if (activeBalances[i] >= newLockedBalance) {
                     _juror.lockedBalance = newLockedBalance;
 
                     // Check repeated juror, we assume jurors come ordered from tree search. Note that since the tree
                     // search can be called more than once, if some juror doesn't have enough balance, the final
                     // result of this function may not be ordered and contain repeated entries.
-                    if (jurorsLength > 0 && jurors[jurorsLength - 1] == juror) {
-                        weights[jurorsLength - 1]++;
+                    if (outputLength > 0 && jurors[outputLength - 1] == juror) {
+                        weights[outputLength - 1]++;
                     } else {
-                        jurors[jurorsLength] = juror;
-                        weights[jurorsLength]++;
-                        jurorsLength++;
+                        jurors[outputLength] = juror;
+                        weights[outputLength]++;
+                        outputLength++;
                     }
-                    filledSeats++;
+                    selectedJurors++;
 
                     //                _disputeId
                     emit JurorDrafted(_params[1], juror);
-                    roundSeatsLeft--;
+                    batchRequestedJurors--;
                 }
             }
-            sortitionIteration++;
         }
     }
 

--- a/contracts/JurorsRegistry.sol
+++ b/contracts/JurorsRegistry.sol
@@ -27,6 +27,8 @@ contract JurorsRegistry is Initializable, IsContract, IJurorsRegistry, ERC900, A
     string internal constant ERROR_INVALID_ZERO_AMOUNT = "JR_INVALID_ZERO_AMOUNT";
     string internal constant ERROR_INVALID_ACTIVATION_AMOUNT = "JR_INVALID_ACTIVATION_AMOUNT";
     string internal constant ERROR_INVALID_DEACTIVATION_AMOUNT = "JR_INVALID_DEACTIVATION_AMOUNT";
+    string internal constant ERROR_INVALID_LOCKED_AMOUNTS_LENGTH = "JR_INVALID_LOCKED_AMOUNTS_LEN";
+    string internal constant ERROR_INVALID_REWARDED_JURORS_LENGTH = "JR_INVALID_REWARDED_JURORS_LEN";
     string internal constant ERROR_ACTIVE_BALANCE_BELOW_MIN = "JR_ACTIVE_BALANCE_BELOW_MIN";
     string internal constant ERROR_NOT_ENOUGH_AVAILABLE_BALANCE = "JR_NOT_ENOUGH_AVAILABLE_BALANCE";
     string internal constant ERROR_CANNOT_REDUCE_DEACTIVATION_REQUEST = "JR_CANT_REDUCE_DEACTIVATION_REQ";
@@ -289,9 +291,8 @@ contract JurorsRegistry is Initializable, IsContract, IJurorsRegistry, ERC900, A
         onlyOwner
         returns (uint256)
     {
-        // TODO: should we add validations for this?
-        // we assume this: require(_jurors.length == _slashJurors.length);
-        // we assume this: require(_jurors.length == _lockedAmounts.length);
+        require(_jurors.length == _lockedAmounts.length, ERROR_INVALID_LOCKED_AMOUNTS_LENGTH);
+        require(_jurors.length == _rewardedJurors.length, ERROR_INVALID_REWARDED_JURORS_LENGTH);
 
         uint64 nextTermId = _termId + 1;
         uint256 collectedTokens;

--- a/contracts/lib/Checkpointing.sol
+++ b/contracts/lib/Checkpointing.sol
@@ -142,12 +142,6 @@ library Checkpointing {
             return uint256(0);
         }
 
-        // If the requested time is equal to or after the time of the latest registered value, return latest value
-        uint256 lastIndex = length - 1;
-        if (_time >= self.history[lastIndex].time) {
-            return uint256(self.history[lastIndex].value);
-        }
-
         // If the requested time is previous to the first registered value, return zero to denote missing checkpoint
         if (_time < self.history[0].time) {
             return uint256(0);
@@ -155,7 +149,7 @@ library Checkpointing {
 
         // Execute a binary search between the checkpointed times of the history
         uint256 low = 0;
-        uint256 high = lastIndex;
+        uint256 high = length - 1;
 
         while (high > low) {
             uint256 mid = (high + low + 1) / 2;

--- a/contracts/lib/HexSumTree.sol
+++ b/contracts/lib/HexSumTree.sol
@@ -115,7 +115,7 @@ library HexSumTree {
         uint256 lastValue = getItem(self, _key);
         _add(self, LEAVES_LEVEL, _key, _time, _value);
 
-        // Update sums cached in the non-leaf nodes. Note that overflows is being checked at the end of the whole update.
+        // Update sums cached in the non-leaf nodes. Note that overflows are being checked at the end of the whole update.
         if (_value > lastValue) {
             _updateSums(self, _key, _time, _value - lastValue, true);
         } else if (_value < lastValue) {
@@ -263,7 +263,7 @@ library HexSumTree {
         uint256 mask = uint256(-1);
         uint256 ancestorKey = _key;
         uint256 currentHeight = getHeight(self);
-        for (uint256 level = 1; level <= currentHeight; level++) {
+        for (uint256 level = LEAVES_LEVEL + 1; level <= currentHeight; level++) {
             // Build a mask to get the key of the ancestor at a certain level. For example:
             // Level  0: leaves don't have children
             // Level  1: 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0 (up to 16 leaves)
@@ -363,7 +363,7 @@ library HexSumTree {
             if (subtreeIncludedValues > 0) {
                 // If the child node being analyzed is a leaf, add it to the list of results a number of times equals
                 // to the number of values that were included in it. Otherwise, descend one level
-                if (_params.level == 0) {
+                if (_params.level == LEAVES_LEVEL) {
                     _copyFoundNode(_params.foundValues, subtreeIncludedValues, childNodeKey, _resultKeys, childNodeValue, _resultValues);
                 } else {
                     SearchParams memory nextLevelParams = SearchParams(_params.time, _params.level - 1, childNodeKey, _params.foundValues, _params.visitedTotal);

--- a/contracts/lib/JurorsTreeSortition.sol
+++ b/contracts/lib/JurorsTreeSortition.sol
@@ -23,7 +23,7 @@ library JurorsTreeSortition {
     * @return jurorsIds List of juror ids obtained based on the requested search
     * @return jurorsBalances List of active balances for each juror obtained based on the requested search
     */
-    function multiSortition(
+    function batchedRandomSearch(
         HexSumTree.Tree storage tree,
         bytes32 _termRandomness,
         uint256 _disputeId,
@@ -37,7 +37,7 @@ library JurorsTreeSortition {
         view
         returns (uint256[] jurorsIds, uint256[] jurorsBalances)
     {
-        (uint256 low, uint256 high) = getActiveBalancesBatchBounds(tree, _termId, _selectedJurors, _batchRequestedJurors, _roundRequestedJurors);
+        (uint256 low, uint256 high) = getSearchBatchBounds(tree, _termId, _selectedJurors, _batchRequestedJurors, _roundRequestedJurors);
         uint256[] memory balances = _computeSearchRandomBalances(_randomnessHash(_termRandomness, _disputeId, _sortitionIteration), _batchRequestedJurors, low, high);
         (jurorsIds, jurorsBalances) = tree.search(balances, _termId);
 
@@ -54,7 +54,7 @@ library JurorsTreeSortition {
     * @return low Low bound to be used for the sortition to draft the requested number of jurors for the given batch
     * @return high High bound to be used for the sortition to draft the requested number of jurors for the given batch
     */
-    function getActiveBalancesBatchBounds(
+    function getSearchBatchBounds(
         HexSumTree.Tree storage tree,
         uint64 _termId,
         uint256 _selectedJurors,
@@ -65,11 +65,11 @@ library JurorsTreeSortition {
         view
         returns (uint256 low, uint256 high)
     {
-        // Note that the low bound will be always equal to the previous high bound incremented by one, or zero for the
+        // Note that the low bound will be always equal to the previous high bound incremented by one, or one for the
         // first iteration. Thus, we can make sure we are not excluding any juror from the tree.
         uint256 totalActiveBalance = tree.getTotalAt(_termId, true);
         uint256 ratio = totalActiveBalance / _roundRequestedJurors;
-        low = _selectedJurors == uint256(0) ? uint256(0) : (_selectedJurors * ratio) + 1;
+        low = _selectedJurors == uint256(0) ? uint256(1) : (_selectedJurors * ratio) + 1;
 
         // This function assumes that `_roundRequestedJurors` is greater than or equal to `newSelectedJurors`
         uint256 newSelectedJurors = _selectedJurors + _batchRequestedJurors;
@@ -83,15 +83,15 @@ library JurorsTreeSortition {
     * @dev Get a random list of active balances to be searched in the jurors tree for a given draft batch
     * @param _randomnessHash Hash to be used as random seed
     * @param _batchRequestedJurors Number of jurors to be selected in the given batch of the draft
-    * @param _lowActiveBalanceBatchBound Low bound to be used for the sortition batch to draft the requested number of jurors
-    * @param _highActiveBalanceBatchBound High bound to be used for the sortition batch to draft the requested number of jurors
+    * @param _lowBatchBound Low bound to be used for the sortition batch to draft the requested number of jurors
+    * @param _highBatchBound High bound to be used for the sortition batch to draft the requested number of jurors
     * @return Random list of active balances to be searched in the jurors tree for the given draft batch
     */
     function _computeSearchRandomBalances(
         bytes32 _randomnessHash,
         uint256 _batchRequestedJurors,
-        uint256 _lowActiveBalanceBatchBound,
-        uint256 _highActiveBalanceBatchBound
+        uint256 _lowBatchBound,
+        uint256 _highBatchBound
     )
         internal
         pure
@@ -99,13 +99,13 @@ library JurorsTreeSortition {
     {
         // Calculate the interval to be used to search the balances in the tree. Since we are using a modulo function
         // to compute the random balances to be searched, we add one to the difference to make sure the last number
-        // of the range is also included. For example, to compute a range [0,10] we need to compute using modulo 11.
-        uint256 activeBalanceInterval = _highActiveBalanceBatchBound - _lowActiveBalanceBatchBound + 1;
+        // of the range is also included. For example, to compute a range [1,10] we need to compute using modulo 10.
+        uint256 interval = _highBatchBound - _lowBatchBound + 1;
         uint256[] memory balances = new uint256[](_batchRequestedJurors);
 
         // Compute an ordered list of random active balance to be searched in the jurors tree
         for(uint256 batchJurorNumber = 0; batchJurorNumber < _batchRequestedJurors; batchJurorNumber++) {
-            balances[batchJurorNumber] = _computeRandomBalance(_randomnessHash, batchJurorNumber, _lowActiveBalanceBatchBound, activeBalanceInterval);
+            balances[batchJurorNumber] = _computeRandomBalance(_randomnessHash, batchJurorNumber, _lowBatchBound, interval);
             for(uint256 i = batchJurorNumber; i > 0 && balances[i] < balances[i - 1]; i--) {
                 uint256 tmp = balances[i - 1];
                 balances[i - 1] = balances[i];
@@ -119,15 +119,15 @@ library JurorsTreeSortition {
     * @dev Get a random active balance to be searched in the jurors tree for a given juror number of the draft batch
     * @param _randomnessHash Hash to be used as random seed
     * @param _batchJurorNumber Number of the juror to be selected in the given batch of the draft
-    * @param _lowActiveBalanceBatchBound Low bound to be used for the sortition batch to draft the requested juror number
-    * @param _activeBalanceInterval Active balance interval to be used for the sortition batch to draft the requested juror number
+    * @param _lowBatchBound Low bound to be used for the sortition batch to draft the requested juror number
+    * @param _interval Bounds interval to be used for the sortition batch to draft the requested juror number
     * @return Random active balance to be searched in the jurors tree for the given juror number of the draft batch
     */
     function _computeRandomBalance(
         bytes32 _randomnessHash,
         uint256 _batchJurorNumber,
-        uint256 _lowActiveBalanceBatchBound,
-        uint256 _activeBalanceInterval
+        uint256 _lowBatchBound,
+        uint256 _interval
     )
         internal
         pure
@@ -138,7 +138,7 @@ library JurorsTreeSortition {
 
         // Compute a random active balance to be searched in the jurors tree using the generated seed within the
         // boundaries computed for the current batch.
-        return _lowActiveBalanceBatchBound + uint256(seed) % _activeBalanceInterval;
+        return _lowBatchBound + uint256(seed) % _interval;
     }
 
     /**

--- a/contracts/lib/JurorsTreeSortition.sol
+++ b/contracts/lib/JurorsTreeSortition.sol
@@ -9,6 +9,8 @@ import "./HexSumTree.sol";
 library JurorsTreeSortition {
     using HexSumTree for HexSumTree.Tree;
 
+    string internal constant ERROR_SORTITION_LENGTHS_MISMATCH = "TREE_SORTITION_LENGTHS_MISMATCH";
+
     /**
     * @dev Search random items in the tree based on certain restrictions
     * @param _termRandomness Randomness to compute the seed for the draft
@@ -37,7 +39,10 @@ library JurorsTreeSortition {
     {
         (uint256 low, uint256 high) = getActiveBalancesBatchBounds(tree, _termId, _selectedJurors, _batchRequestedJurors, _roundRequestedJurors);
         uint256[] memory balances = _computeSearchRandomBalances(_randomnessHash(_termRandomness, _disputeId, _sortitionIteration), _batchRequestedJurors, low, high);
-        return tree.search(balances, _termId);
+        (jurorsIds, jurorsBalances) = tree.search(balances, _termId);
+
+        require(jurorsIds.length == jurorsBalances.length, ERROR_SORTITION_LENGTHS_MISMATCH);
+        require(jurorsIds.length == _batchRequestedJurors, ERROR_SORTITION_LENGTHS_MISMATCH);
     }
 
     /**

--- a/contracts/lib/JurorsTreeSortition.sol
+++ b/contracts/lib/JurorsTreeSortition.sol
@@ -97,9 +97,9 @@ library JurorsTreeSortition {
         pure
         returns (uint256[])
     {
-        // Calculate the interval to be used to search the balances in the tree. Since we are using a module function
+        // Calculate the interval to be used to search the balances in the tree. Since we are using a modulo function
         // to compute the random balances to be searched, we add one to the difference to make sure the last number
-        // of the range is also included. For example, to compute a range [0,10] we need to compute using module 11.
+        // of the range is also included. For example, to compute a range [0,10] we need to compute using modulo 11.
         uint256 activeBalanceInterval = _highActiveBalanceBatchBound - _lowActiveBalanceBatchBound + 1;
         uint256[] memory balances = new uint256[](_batchRequestedJurors);
 

--- a/contracts/test/registry/JurorsRegistryMock.sol
+++ b/contracts/test/registry/JurorsRegistryMock.sol
@@ -6,16 +6,39 @@ import "../lib/TimeHelpersMock.sol";
 
 contract JurorsRegistryMock is JurorsRegistry, TimeHelpersMock {
     bool internal treeSearchHijacked;
+    bool internal nextDraftMocked;
+    address[] public mockedSelectedJurors;
+    uint256[] public mockedWeights;
 
-    function mock_hijackTreeSearch() external {
+    function mockHijackTreeSearch() external {
         treeSearchHijacked = true;
     }
 
-    function _treeSearch(uint256[7] _params) internal view returns (uint256[] keys, uint256[] nodeValues) {
-        if (!treeSearchHijacked) {
-            return super._treeSearch(_params);
+    function mockNextDraft(address[] _selectedJurors, uint256[] _weights) external {
+        nextDraftMocked = true;
+
+        delete mockedSelectedJurors;
+        for (uint256 i = 0; i < _selectedJurors.length; i++) {
+            mockedSelectedJurors.push(_selectedJurors[i]);
         }
 
+        delete mockedWeights;
+        for (uint256 j = 0; j < _weights.length; j++) {
+            mockedWeights.push(_weights[j]);
+        }
+    }
+
+    function _treeSearch(uint256[7] _params) internal view returns (uint256[], uint256[]) {
+        if (treeSearchHijacked) {
+            return _runHijackedSearch(_params);
+        }
+        if (nextDraftMocked) {
+            return _runMockedSearch(_params);
+        }
+        return super._treeSearch(_params);
+    }
+
+    function _runHijackedSearch(uint256[7] _params) internal view returns (uint256[] keys, uint256[] nodeValues) {
         uint256 _jurorsRequested = _params[4];
 
         keys = new uint256[](_jurorsRequested);
@@ -25,5 +48,30 @@ contract JurorsRegistryMock is JurorsRegistry, TimeHelpersMock {
             keys[i] = key;
             nodeValues[i] = tree.getItem(key);
         }
+    }
+
+    function _runMockedSearch(uint256[7] _params) internal returns (uint256[] ids, uint256[] activeBalances) {
+        uint256 totalLength = 0;
+        for (uint256 k = 0; k < mockedWeights.length; k++) {
+            totalLength += mockedWeights[k];
+        }
+
+        ids = new uint256[](totalLength);
+        activeBalances = new uint256[](totalLength);
+
+        uint256 index = 0;
+        for (uint256 i = 0; i < mockedSelectedJurors.length; i++) {
+            address juror = mockedSelectedJurors[i];
+            uint256 id = jurorsByAddress[juror].id;
+            uint256 activeBalance = tree.getItem(id);
+
+            for (uint256 j = 0; j < mockedWeights[i]; j++) {
+                ids[index] = id;
+                activeBalances[index] = activeBalance;
+                index++;
+            }
+        }
+
+        nextDraftMocked = false;
     }
 }

--- a/contracts/test/registry/JurorsRegistryOwnerMock.sol
+++ b/contracts/test/registry/JurorsRegistryOwnerMock.sol
@@ -8,7 +8,7 @@ contract JurorsRegistryOwnerMock is IJurorsRegistryOwner {
     uint64 internal termId;
     IJurorsRegistry internal registry;
 
-    event Slashed(uint256 collectedTokens);
+    event Slashed(uint256 collected);
     event Collected(bool collected);
     event Drafted(address[] addresses, uint64[] weights, uint256 outputLength, uint64 selectedJurors);
 
@@ -36,8 +36,8 @@ contract JurorsRegistryOwnerMock is IJurorsRegistryOwner {
         registry.burnTokens(_amount);
     }
 
-    function slashOrUnlock(address[] _jurors, uint256[] _penalties, bool[] _slashJurors) public {
-        uint256 collectedTokens = registry.slashOrUnlock(termId, _jurors, _penalties, _slashJurors);
+    function slashOrUnlock(address[] _jurors, uint256[] _lockedAmounts, bool[] _rewardedJurors) public {
+        uint256 collectedTokens = registry.slashOrUnlock(termId, _jurors, _lockedAmounts, _rewardedJurors);
         emit Slashed(collectedTokens);
     }
 

--- a/contracts/test/registry/JurorsRegistryOwnerMock.sol
+++ b/contracts/test/registry/JurorsRegistryOwnerMock.sol
@@ -10,6 +10,7 @@ contract JurorsRegistryOwnerMock is IJurorsRegistryOwner {
 
     event Slashed(uint256 collectedTokens);
     event Collected(bool collected);
+    event Drafted(address[] addresses, uint64[] weights, uint256 outputLength, uint64 selectedJurors);
 
     constructor(IJurorsRegistry _registry) public {
         registry = _registry;
@@ -43,5 +44,28 @@ contract JurorsRegistryOwnerMock is IJurorsRegistryOwner {
     function collect(address _juror, uint256 _amount) public {
         bool collected = registry.collectTokens(_juror, _amount, termId);
         emit Collected(collected);
+    }
+
+    function draft(
+        bytes32 _termRandomness,
+        uint256 _disputeId,
+        uint256 _selectedJurors,
+        uint256 _batchRequestedJurors,
+        uint64 _roundRequestedJurors,
+        uint16 _lockPct
+    )
+        public
+    {
+        uint256[7] memory draftParams = [
+            uint256(_termRandomness),
+            _disputeId,
+            termId,
+            _selectedJurors,
+            _batchRequestedJurors,
+            _roundRequestedJurors,
+            _lockPct
+        ];
+        (address[] memory jurors, uint64[] memory weights, uint256 outputLength, uint64 selectedJurors) = registry.draft(draftParams);
+        emit Drafted(jurors, weights, outputLength, selectedJurors);
     }
 }

--- a/contracts/test/tree/JurorsTreeSortitionMock.sol
+++ b/contracts/test/tree/JurorsTreeSortitionMock.sol
@@ -7,7 +7,7 @@ import "../../lib/JurorsTreeSortition.sol";
 contract JurorsTreeSortitionMock is HexSumTreeMock {
     using JurorsTreeSortition for HexSumTree.Tree;
 
-    function multiSortition(
+    function batchedRandomSearch(
         bytes32 _termRandomness,
         uint256 _disputeId,
         uint64 _termId,
@@ -20,15 +20,15 @@ contract JurorsTreeSortitionMock is HexSumTreeMock {
         view
         returns (uint256[] jurorsIds, uint256[] jurorsBalances)
     {
-        return tree.multiSortition(_termRandomness, _disputeId, _termId, _selectedJurors, _batchRequestedJurors, _roundRequestedJurors, _sortitionIteration);
+        return tree.batchedRandomSearch(_termRandomness, _disputeId, _termId, _selectedJurors, _batchRequestedJurors, _roundRequestedJurors, _sortitionIteration);
     }
 
-    function getActiveBalancesBatchBounds(uint64 _termId, uint256 _selectedJurors, uint256 _batchRequestedJurors, uint256 _roundRequestedJurors)
+    function getSearchBatchBounds(uint64 _termId, uint256 _selectedJurors, uint256 _batchRequestedJurors, uint256 _roundRequestedJurors)
         public
         view
         returns (uint256, uint256)
     {
-        return tree.getActiveBalancesBatchBounds(_termId, _selectedJurors, _batchRequestedJurors, _roundRequestedJurors);
+        return tree.getSearchBatchBounds(_termId, _selectedJurors, _batchRequestedJurors, _roundRequestedJurors);
     }
 
     function computeSearchRandomBalances(

--- a/test/court-batches.js
+++ b/test/court-batches.js
@@ -137,7 +137,7 @@ contract('Court: Batches', ([ rich, arbitrable, juror1, juror2, juror3, juror4, 
     context('hijacked', () => {
       beforeEach(async () => {
         // registry searches always return jurors in the order that they were added to the registry
-        await this.jurorsRegistry.mock_hijackTreeSearch()
+        await this.jurorsRegistry.mockHijackTreeSearch()
         await createDispute()
       })
 
@@ -297,7 +297,7 @@ contract('Court: Batches', ([ rich, arbitrable, juror1, juror2, juror3, juror4, 
 
     beforeEach(async () => {
       // registry searches always return jurors in the order that they were added to the registry
-      await this.jurorsRegistry.mock_hijackTreeSearch()
+      await this.jurorsRegistry.mockHijackTreeSearch()
 
       // create dispute
       await createDispute()

--- a/test/court-disputes.js
+++ b/test/court-disputes.js
@@ -128,7 +128,7 @@ contract('Court: Disputes', ([ rich, juror1, juror2, juror3, other, appealMaker,
     })
 
     // tree searches always return jurors in the order that they were added to the tree
-    await this.jurorsRegistry.mock_hijackTreeSearch()
+    await this.jurorsRegistry.mockHijackTreeSearch()
 
     assert.equal(await this.jurorsRegistry.token(), this.anj.address, 'court token')
     await assertEqualBN(this.jurorsRegistry.totalActiveBalance(), 0, 'empty sum tree')

--- a/test/court-final-appeal-non-exact.js
+++ b/test/court-final-appeal-non-exact.js
@@ -102,7 +102,7 @@ contract('Court: final appeal (non-exact)', ([ poor, rich, juror1, juror2, juror
       jurorsMinActiveBalance,
     })
 
-    await this.jurorsRegistry.mock_hijackTreeSearch()
+    await this.jurorsRegistry.mockHijackTreeSearch()
 
     assert.equal(await this.jurorsRegistry.token(), this.anj.address, 'court token')
     await assertEqualBN(this.jurorsRegistry.totalActiveBalance(), 0, 'empty sum tree')

--- a/test/registry/jurors-registry-drafting.js
+++ b/test/registry/jurors-registry-drafting.js
@@ -173,7 +173,7 @@ contract('JurorsRegistry drafting', ([_, juror500, juror1000, juror1500, juror20
             context('when some jurors were requested', () => {
               const roundRequestedJurors = 10
 
-              context('when the jurors are activated for the following term', () => {
+              context('when the juror is activated for the following term', () => {
                 context('for the first batch', () => {
                   const batchRequestedJurors = 3
 
@@ -187,7 +187,7 @@ contract('JurorsRegistry drafting', ([_, juror500, juror1000, juror1500, juror20
                 })
               })
 
-              context('when the jurors are activated for the current term', () => {
+              context('when the juror is activated for the current term', () => {
                 beforeEach('increment term', async () => {
                   await registryOwner.incrementTerm()
                 })

--- a/test/registry/jurors-registry-drafting.js
+++ b/test/registry/jurors-registry-drafting.js
@@ -1,5 +1,441 @@
-// TODO: implement
+const { bn, bigExp } = require('../helpers/numbers')(web3)
+const { getEventAt } = require('@aragon/test-helpers/events')
+const { assertRevert } = require('@aragon/test-helpers/assertThrow')
 
-contract('JurorsRegistry drafting', ([_]) => {
-  describe('draft', () => {})
+const JurorsRegistry = artifacts.require('JurorsRegistry')
+const MiniMeToken = artifacts.require('MiniMeToken')
+const JurorsRegistryOwnerMock = artifacts.require('JurorsRegistryOwnerMock')
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+const NO_DATA = '0x0000000000000000000000000000000000000000000000000000000000000000'
+
+contract('JurorsRegistry drafting', ([_, juror500, juror1000, juror1500, juror2000, juror2500, juror3000, juror3500, juror4000]) => {
+  let registry, registryOwner, ANJ
+
+  const DRAFT_LOCK_PCT = bn(2000) // 20%
+  const MIN_ACTIVE_AMOUNT = bigExp(100, 18)
+  const ACTIVATE_DATA = web3.sha3('activate(uint256)').slice(0, 10)
+
+  const jurors = [
+    { address: juror500,  initialActiveBalance: bigExp(500,  18) },
+    { address: juror1000, initialActiveBalance: bigExp(1000, 18) },
+    { address: juror1500, initialActiveBalance: bigExp(1500, 18) },
+    { address: juror2000, initialActiveBalance: bigExp(2000, 18) },
+    { address: juror2500, initialActiveBalance: bigExp(2500, 18) },
+    { address: juror3000, initialActiveBalance: bigExp(3000, 18) },
+    { address: juror3500, initialActiveBalance: bigExp(3500, 18) },
+    { address: juror4000, initialActiveBalance: bigExp(4000, 18) },
+  ]
+
+  beforeEach('create base contracts', async () => {
+    registry = await JurorsRegistry.new()
+    registryOwner = await JurorsRegistryOwnerMock.new(registry.address)
+    ANJ = await MiniMeToken.new(ZERO_ADDRESS, ZERO_ADDRESS, 0, 'n', 18, 'ANJ', true)
+  })
+
+  describe('draft', () => {
+    const draft = async ({ termRandomness = NO_DATA, disputeId = 0, selectedJurors = 0, batchRequestedJurors, roundRequestedJurors, lockPct = DRAFT_LOCK_PCT }) => {
+      const receipt = await registryOwner.draft(termRandomness, disputeId, selectedJurors, batchRequestedJurors, roundRequestedJurors, lockPct)
+      return getEventAt(receipt, 'Drafted').args
+    }
+
+    context('when the registry is already initialized', () => {
+      beforeEach('initialize registry and mint ANJ for jurors', async () => {
+        await registry.init(registryOwner.address, ANJ.address, MIN_ACTIVE_AMOUNT)
+        for (let i = 0; i < jurors.length; i++) {
+          await ANJ.generateTokens(jurors[i].address, jurors[i].initialActiveBalance)
+        }
+      })
+
+      context('when the sender is the registry owner', () => {
+        const assertEmptyDraftOutput = output => {
+          const { addresses, weights, outputLength, selectedJurors } = output
+
+          assert.equal(outputLength.toString(), 0, 'output length does not match')
+          assert.equal(selectedJurors.toString(), 0, 'amount of selected jurors does not match')
+
+          assert.isEmpty(addresses, 'jurors address do not match')
+          assert.isEmpty(weights, 'jurors weights do not match')
+        }
+
+        const assertDraftOutput = async (output, requestedJurors, expectedAddresses, expectedWeights, previousLockedBalances = {}) => {
+          const { addresses, weights, outputLength, selectedJurors } = output
+
+          assert.equal(outputLength.toString(), expectedWeights.length, 'output length does not match')
+          assert.equal(outputLength.toString(), expectedAddresses.length, 'output length does not match')
+
+          assert.equal(selectedJurors.toString(), requestedJurors, 'amount of selected jurors does not match')
+          assert.equal(selectedJurors, expectedWeights.reduce((a, b) => a + b, 0), 'total weight does not match')
+
+          assert.lengthOf(weights, requestedJurors, 'jurors weights do not match')
+          assert.lengthOf(addresses, requestedJurors, 'jurors address do not match')
+
+          for (let i = 0; i < requestedJurors; i++) {
+            assert.equal(weights[i], expectedWeights[i] || 0, `weight #${i} does not match`)
+            assert.equal(addresses[i], expectedAddresses[i] || ZERO_ADDRESS, `juror address #${i} does not match`)
+
+            if (expectedAddresses[i]) {
+              const lockedBalance = (await registry.balanceOf(expectedAddresses[i]))[2]
+              const previousLockedBalance = previousLockedBalances[expectedAddresses[i]] || 0
+              const expectedLockedBalance = expectedWeights[i] * (MIN_ACTIVE_AMOUNT * DRAFT_LOCK_PCT / 10000)
+              assert.equal(lockedBalance.minus(previousLockedBalance).toString(), expectedLockedBalance, `locked balance for juror #${i} does not match`)
+            }
+          }
+        }
+
+        context('when there are no activated jurors', () => {
+          context('when no jurors were requested', () => {
+            const batchRequestedJurors = 0
+            const roundRequestedJurors = 0
+
+            it('returns empty values', async () => {
+              const output = await draft({ batchRequestedJurors, roundRequestedJurors })
+              assertEmptyDraftOutput(output)
+            })
+          })
+
+          context('when some jurors were requested', () => {
+            const roundRequestedJurors = 10
+
+            context('for the first batch', () => {
+              const batchRequestedJurors = 3
+
+              // NOTE: this scenario is not being handled, the registry trusts the input from the owner and the tree
+              it('reverts', async () => {
+                await assertRevert(draft({ batchRequestedJurors, roundRequestedJurors }))
+              })
+            })
+
+            context('for the second batch', () => {
+              const batchRequestedJurors = 7
+
+              // NOTE: this scenario is not being handled, the registry trusts the input from the owner and the tree
+              it('reverts', async () => {
+                await assertRevert(draft({ batchRequestedJurors, roundRequestedJurors }))
+              })
+            })
+          })
+        })
+
+        context('when there are some activated jurors', () => {
+          context('when there is only one juror activated', () => {
+            beforeEach('activate', async () => {
+              await ANJ.approveAndCall(registry.address, bigExp(500, 18), ACTIVATE_DATA, { from: juror500 })
+            })
+
+            context('when no jurors were requested', () => {
+              const batchRequestedJurors = 0
+              const roundRequestedJurors = 0
+
+              it('returns empty values', async () => {
+                const output = await draft({ batchRequestedJurors, roundRequestedJurors })
+                assertEmptyDraftOutput(output)
+              })
+            })
+
+            context('when some jurors were requested', () => {
+              const roundRequestedJurors = 10
+
+              context('when the jurors are activated for the following term', () => {
+                context('for the first batch', () => {
+                  const batchRequestedJurors = 3
+
+                  // NOTE: this scenario is not being handled, the registry trusts the input from the owner and the tree
+                  it('reverts', async () => {
+                    await assertRevert(draft({ batchRequestedJurors, roundRequestedJurors }))
+                  })
+                })
+
+                context('for the second batch', () => {
+                  const batchRequestedJurors = 7
+
+                  // NOTE: this scenario is not being handled, the registry trusts the input from the owner and the tree
+                  it('reverts', async () => {
+                    await assertRevert(draft({ batchRequestedJurors, roundRequestedJurors }))
+                  })
+                })
+              })
+
+              context('when the jurors are activated for the current term', () => {
+                beforeEach('increment term', async () => {
+                  await registryOwner.incrementTerm()
+                })
+
+                context('when juror has enough unlocked balance to be drafted', () => {
+                  context('for the first batch', () => {
+                    const batchRequestedJurors = 3
+
+                    const expectedWeights = [3]
+                    const expectedAddresses = [juror500]
+
+                    it('returns expected jurors', async () => {
+                      const output = await draft({ batchRequestedJurors, roundRequestedJurors })
+                      await assertDraftOutput(output, batchRequestedJurors, expectedAddresses, expectedWeights)
+                    })
+                  })
+
+                  context('for the second batch', () => {
+                    const batchRequestedJurors = 7
+
+                    const expectedWeights = [7]
+                    const expectedAddresses = [juror500]
+
+                    it('returns expected jurors', async () => {
+                      const output = await draft({ batchRequestedJurors, roundRequestedJurors })
+                      await assertDraftOutput(output, batchRequestedJurors, expectedAddresses, expectedWeights)
+                    })
+                  })
+                })
+
+                context('when juror does not have enough unlocked balance to be drafted', () => {
+                  beforeEach('draft juror', async () => {
+                    // lock per draft is 20% of the min active balance, we need to lock 500 tokens which is 25 seats
+                    await draft({ batchRequestedJurors: 25, roundRequestedJurors: 25 })
+                  })
+
+                  it('reverts', async () => {
+                    await assertRevert(draft({ batchRequestedJurors: 1, roundRequestedJurors: 1 }))
+                  })
+                })
+              })
+            })
+          })
+
+          context('when there are many jurors activated', () => {
+            beforeEach('activate', async () => {
+              for (let i = 0; i < jurors.length; i++) {
+                await ANJ.approveAndCall(registry.address, jurors[i].initialActiveBalance, ACTIVATE_DATA, { from: jurors[i].address })
+              }
+            })
+
+            context('when no jurors were requested', () => {
+              const batchRequestedJurors = 0
+              const roundRequestedJurors = 0
+
+              it('returns empty values', async () => {
+                const output = await draft({ batchRequestedJurors, roundRequestedJurors })
+                assertEmptyDraftOutput(output)
+              })
+            })
+
+            context('when some jurors were requested', () => {
+              context('when there were requested less jurors than the active ones', () => {
+                const roundRequestedJurors = 5
+
+                context('when the jurors are activated for the following term', () => {
+                  context('for the first batch', () => {
+                    const batchRequestedJurors = 1
+
+                    // NOTE: this scenario is not being handled, the registry trusts the input from the owner and the tree
+                    it('reverts', async () => {
+                      await assertRevert(draft({ batchRequestedJurors, roundRequestedJurors }))
+                    })
+                  })
+
+                  context('for the second batch', () => {
+                    const batchRequestedJurors = 4
+
+                    // NOTE: this scenario is not being handled, the registry trusts the input from the owner and the tree
+                    it('reverts', async () => {
+                      await assertRevert(draft({ batchRequestedJurors, roundRequestedJurors }))
+                    })
+                  })
+                })
+
+                context('when the jurors are activated for the current term', () => {
+                  beforeEach('increment term', async () => {
+                    await registryOwner.incrementTerm()
+                  })
+
+                  context('for the first batch', () => {
+                    const batchRequestedJurors = 1
+
+                    const expectedWeights = [1]
+                    const expectedAddresses = [juror1500]
+
+                    it('returns expected jurors', async () => {
+                      const output = await draft({ batchRequestedJurors, roundRequestedJurors })
+                      await assertDraftOutput(output, batchRequestedJurors, expectedAddresses, expectedWeights)
+                    })
+                  })
+
+                  context('for the second batch', () => {
+                    const batchRequestedJurors = 4
+
+                    const expectedWeights = [2, 1, 1]
+                    const expectedAddresses = [juror1500, juror3000, juror3500]
+
+                    it('returns expected jurors', async () => {
+                      const output = await draft({ batchRequestedJurors, roundRequestedJurors })
+                      await assertDraftOutput(output, batchRequestedJurors, expectedAddresses, expectedWeights)
+                    })
+                  })
+                })
+              })
+
+              context('when there were requested more jurors than the active ones', () => {
+                const roundRequestedJurors = 10
+
+                context('when the jurors are activated for the following term', () => {
+                  context('for the first batch', () => {
+                    const batchRequestedJurors = 3
+
+                    // NOTE: this scenario is not being handled, the registry trusts the input from the owner and the tree
+                    it('reverts', async () => {
+                      await assertRevert(draft({ batchRequestedJurors, roundRequestedJurors }))
+                    })
+                  })
+
+                  context('for the second batch', () => {
+                    const batchRequestedJurors = 7
+
+                    // NOTE: this scenario is not being handled, the registry trusts the input from the owner and the tree
+                    it('reverts', async () => {
+                      await assertRevert(draft({ batchRequestedJurors, roundRequestedJurors }))
+                    })
+                  })
+                })
+
+                context('when the jurors are activated for the current term', () => {
+                  beforeEach('increment term', async () => {
+                    await registryOwner.incrementTerm()
+                  })
+
+                  context('when jurors have not been selected for other drafts', () => {
+                    context('for the first batch', () => {
+                      const batchRequestedJurors = 3
+
+                      const expectedWeights = [1, 1, 1]
+                      const expectedAddresses = [juror500, juror1000, juror2000]
+
+                      it('returns expected jurors', async () => {
+                        const output = await draft({ batchRequestedJurors, roundRequestedJurors })
+                        await assertDraftOutput(output, batchRequestedJurors, expectedAddresses, expectedWeights)
+                      })
+
+                      it('changes for different dispute ids', async () => {
+                        const { weights, addresses } = await draft({ disputeId: 1, batchRequestedJurors, roundRequestedJurors })
+                        assert.notEqual(expectedWeights, weights, 'weights should not match')
+                        assert.notEqual(expectedAddresses, addresses, 'jurors addresses should not match')
+                      })
+
+                      it('changes for different term randomness', async () => {
+                        const { weights, addresses } = await draft({ termRandomness: '0x1', batchRequestedJurors, roundRequestedJurors })
+                        assert.notEqual(expectedWeights, weights, 'weights should not match')
+                        assert.notEqual(expectedAddresses, addresses, 'jurors addresses should not match')
+                      })
+                    })
+
+                    context('for the second batch', () => {
+                      const batchRequestedJurors = 7
+
+                      const expectedWeights = [1, 2, 1, 2, 1]
+                      const expectedAddresses = [juror1000, juror1500, juror2000, juror3000, juror3500]
+
+                      it('returns expected jurors', async () => {
+                        const output = await draft({ batchRequestedJurors, roundRequestedJurors })
+                        await assertDraftOutput(output, batchRequestedJurors, expectedAddresses, expectedWeights)
+                      })
+                    })
+                  })
+
+                  context('when jurors have been selected for other drafts', () => {
+                    let previousLockedBalances
+
+                    context('when all jurors have been enough balance to be drafted again', () => {
+                      beforeEach('draft and compute previous locked balances', async () => {
+                        previousLockedBalances = {}
+                        const { addresses, weights, outputLength } = await draft({ batchRequestedJurors: 3, roundRequestedJurors: 3 })
+
+                        for(let i = 0; i < outputLength; i++) {
+                          const lockedBalance = weights[i] * (MIN_ACTIVE_AMOUNT * DRAFT_LOCK_PCT / 10000)
+                          previousLockedBalances[addresses[i]] = (previousLockedBalances[addresses[i]] || 0) + lockedBalance
+                        }
+                      })
+
+                      context('for the first batch', () => {
+                        const batchRequestedJurors = 3
+
+                        const expectedWeights = [1, 1, 1]
+                        const expectedAddresses = [juror500, juror1000, juror2000]
+
+                        it('returns expected jurors', async () => {
+                          const output = await draft({ batchRequestedJurors, roundRequestedJurors })
+                          await assertDraftOutput(output, batchRequestedJurors, expectedAddresses, expectedWeights, previousLockedBalances)
+                        })
+                      })
+
+                      context('for the second batch', () => {
+                        const batchRequestedJurors = 7
+
+                        const expectedWeights = [1, 2, 1, 2, 1]
+                        const expectedAddresses = [juror1000, juror1500, juror2000, juror3000, juror3500]
+
+                        it('returns expected jurors', async () => {
+                          const output = await draft({ batchRequestedJurors, roundRequestedJurors })
+                          await assertDraftOutput(output, batchRequestedJurors, expectedAddresses, expectedWeights, previousLockedBalances)
+                        })
+                      })
+                    })
+
+                    context('when some jurors do not have been enough balance to be drafted again', () => {
+                      beforeEach('draft and compute previous locked balances', async () => {
+                        previousLockedBalances = {}
+
+                        // draft enough times to leave the first juror without unlocked balance
+                        for(let i = 0; i < 50; i++) {
+                          const { addresses, weights, outputLength } = await draft({ batchRequestedJurors: 3, roundRequestedJurors })
+
+                          for(let j = 0; j < outputLength; j++) {
+                            const lockedBalance = weights[j] * (MIN_ACTIVE_AMOUNT * DRAFT_LOCK_PCT / 10000)
+                            previousLockedBalances[addresses[j]] = (previousLockedBalances[addresses[j]] || 0) + lockedBalance
+                          }
+                        }
+                      })
+
+                      context('for the first batch', () => {
+                        const batchRequestedJurors = 3
+
+                        const expectedWeights = [3]
+                        const expectedAddresses = [juror2000]
+
+                        it('returns expected jurors', async () => {
+                          const output = await draft({ batchRequestedJurors, roundRequestedJurors })
+                          await assertDraftOutput(output, batchRequestedJurors, expectedAddresses, expectedWeights, previousLockedBalances)
+                        })
+                      })
+
+                      context('for the second batch', () => {
+                        const batchRequestedJurors = 7
+
+                        const expectedWeights = [2, 1, 2, 2]
+                        const expectedAddresses = [juror1500, juror2000, juror3000, juror3500]
+
+                        it('returns expected jurors', async () => {
+                          const output = await draft({ batchRequestedJurors, roundRequestedJurors })
+                          await assertDraftOutput(output, batchRequestedJurors, expectedAddresses, expectedWeights, previousLockedBalances)
+                        })
+                      })
+                    })
+                  })
+                })
+              })
+            })
+          })
+        })
+      })
+
+      context('when the sender is not the registry owner', () => {
+        it('reverts', async () => {
+          await assertRevert(registry.draft(new Array(7)), 'JR_SENDER_NOT_OWNER')
+        })
+      })
+    })
+
+    context('when the registry is not initialized', () => {
+      it('reverts', async () => {
+        await assertRevert(draft({ batchRequestedJurors: 1, roundRequestedJurors: 1 }), 'JR_SENDER_NOT_OWNER')
+      })
+    })
+  })
 })

--- a/test/registry/jurors-registry-slashing.js
+++ b/test/registry/jurors-registry-slashing.js
@@ -1,18 +1,23 @@
-const { bigExp } = require('../helpers/numbers')(web3)
+const { bn, bigExp } = require('../helpers/numbers')(web3)
+const { getEventAt } = require('@aragon/test-helpers/events')
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
 const { decodeEventsOfType } = require('../helpers/decodeEvent')
 const { assertEvent, assertAmountOfEvents } = require('@aragon/test-helpers/assertEvent')(web3)
 
-const JurorsRegistry = artifacts.require('JurorsRegistry')
 const MiniMeToken = artifacts.require('MiniMeToken')
+const JurorsRegistry = artifacts.require('JurorsRegistry')
 const JurorsRegistryOwnerMock = artifacts.require('JurorsRegistryOwnerMock')
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+const NO_DATA = '0x0000000000000000000000000000000000000000000000000000000000000000'
 
-contract('JurorsRegistry slashing', ([_, juror, anyone]) => {
+contract('JurorsRegistry slashing', ([_, juror, secondJuror, thirdJuror, anyone]) => {
   let registry, registryOwner, ANJ
 
+  const ACTIVATE_DATA = web3.sha3('activate(uint256)').slice(0, 10)
   const MIN_ACTIVE_AMOUNT = bigExp(100, 18)
+  const DRAFT_LOCK_PCT = bn(2000) // 20%
+  const DRAFT_LOCK_AMOUNT = MIN_ACTIVE_AMOUNT.mul(DRAFT_LOCK_PCT.div(10000))
 
   beforeEach('create base contracts', async () => {
     registry = await JurorsRegistry.new()
@@ -20,8 +25,161 @@ contract('JurorsRegistry slashing', ([_, juror, anyone]) => {
     ANJ = await MiniMeToken.new(ZERO_ADDRESS, ZERO_ADDRESS, 0, 'n', 18, 'ANJ', true)
   })
 
-  describe('slash', () => {
-    // TODO: implement
+  describe('slashOrUnlock', () => {
+    context('when the registry is initialized', () => {
+      beforeEach('initialize registry', async () => {
+        await registry.init(registryOwner.address, ANJ.address, MIN_ACTIVE_AMOUNT)
+      })
+
+      context('when the sender is the owner', () => {
+        beforeEach('activate jurors', async () => {
+          const firstJurorBalance = MIN_ACTIVE_AMOUNT.mul(10)
+          await ANJ.generateTokens(juror, firstJurorBalance)
+          await ANJ.approveAndCall(registry.address, firstJurorBalance, ACTIVATE_DATA, { from: juror })
+
+          const secondJurorBalance = MIN_ACTIVE_AMOUNT.mul(5)
+          await ANJ.generateTokens(secondJuror, secondJurorBalance)
+          await ANJ.approveAndCall(registry.address, secondJurorBalance, ACTIVATE_DATA, { from: secondJuror })
+
+          const thirdJurorBalance = MIN_ACTIVE_AMOUNT.mul(20)
+          await ANJ.generateTokens(thirdJuror, thirdJurorBalance)
+          await ANJ.approveAndCall(registry.address, thirdJurorBalance, ACTIVATE_DATA, { from: thirdJuror })
+
+          await registryOwner.incrementTerm()
+        })
+
+        context('when no jurors are given', () => {
+          const jurors = []
+          const lockedAmounts = [MIN_ACTIVE_AMOUNT, MIN_ACTIVE_AMOUNT.div(2), MIN_ACTIVE_AMOUNT.mul(3)]
+          const rewardedJurors = [true, false, false]
+
+          it('does not collect tokens', async () => {
+            const receipt = await registryOwner.slashOrUnlock(jurors, lockedAmounts, rewardedJurors)
+            assertEvent(receipt, 'Slashed', { collected: 0 })
+          })
+
+          it('does not affect the balances of the jurors', async () => {
+            const previousFirstJurorBalances = await registry.balanceOf(juror)
+            const previousSecondJurorBalances = await registry.balanceOf(secondJuror)
+            const previousThirdJurorBalances = await registry.balanceOf(thirdJuror)
+
+            await registryOwner.slashOrUnlock(jurors, lockedAmounts, rewardedJurors)
+
+            const currentJurorBalances = await registry.balanceOf(juror)
+            const currentSecondJurorBalances = await registry.balanceOf(secondJuror)
+            const currentThirdJurorBalances = await registry.balanceOf(thirdJuror)
+
+            for (let i = 0; i < currentJurorBalances.length; i++) {
+              assert.equal(previousFirstJurorBalances[i].toString(), currentJurorBalances[i].toString(), `first juror balance #${i} does not match`)
+              assert.equal(previousSecondJurorBalances[i].toString(), currentSecondJurorBalances[i].toString(), `second juror balance #${i} does not match`)
+              assert.equal(previousThirdJurorBalances[i].toString(), currentThirdJurorBalances[i].toString(), `third juror balance #${i} does not match`)
+            }
+          })
+        })
+
+        context('when some jurors are given', () => {
+          const jurors = [juror, secondJuror, thirdJuror]
+          const rewardedJurors = [false, true, false]
+
+          beforeEach('draft jurors', async () => {
+            // Given draft params will result in the first juror selected 3 times, the second selected once, and the third selected 6 times
+            const termRandomness = NO_DATA
+            const disputeId = 0
+            const selectedJurors = 0
+            const batchRequestedJurors = 10
+            const roundRequestedJurors = 10
+
+            const receipt = await registryOwner.draft(termRandomness, disputeId, selectedJurors, batchRequestedJurors, roundRequestedJurors, DRAFT_LOCK_PCT)
+            const { addresses, weights } = getEventAt(receipt, 'Drafted').args
+
+            assert.equal(addresses[0], juror, 'first drafted address does not match')
+            assert.equal(addresses[1], secondJuror, 'second drafted address does not match')
+            assert.equal(addresses[2], thirdJuror, 'third drafted address does not match')
+            assert.equal(weights[0].toString(), 3, 'first drafted weight does not match')
+            assert.equal(weights[1].toString(), 1, 'second drafted weight does not match')
+            assert.equal(weights[2].toString(), 6, 'third drafted weight does not match')
+          })
+
+          context('when given lock amounts are valid', () => {
+            const lockedAmounts = [DRAFT_LOCK_AMOUNT.mul(3), DRAFT_LOCK_AMOUNT, DRAFT_LOCK_AMOUNT.mul(6)]
+
+            it('collect tokens the slashed amounts', async () => {
+              const receipt = await registryOwner.slashOrUnlock(jurors, lockedAmounts, rewardedJurors)
+              assertEvent(receipt, 'Slashed', { collected: DRAFT_LOCK_AMOUNT.mul(9) })
+            })
+
+            it('reimburses the lock balances of the rewarded jurors', async () => {
+              const [previousActiveBalance, previousAvailableBalance, previousLockedBalance, previousDeactivationBalance] = await registry.balanceOf(secondJuror)
+
+              await registryOwner.slashOrUnlock(jurors, lockedAmounts, rewardedJurors)
+
+              const [currentActiveBalance, currentAvailableBalance, currentLockedBalance, currentDeactivationBalance] = await registry.balanceOf(secondJuror)
+              assert.equal(previousLockedBalance.minus(DRAFT_LOCK_AMOUNT).toString(), currentLockedBalance.toString(), 'rewarded juror locked balance does not match')
+              assert.equal(previousActiveBalance.toString(), currentActiveBalance.toString(), 'rewarded juror active balance does not match')
+              assert.equal(previousAvailableBalance.toString(), currentAvailableBalance.toString(), 'rewarded juror available balance does not match')
+              assert.equal(previousDeactivationBalance.toString(), currentDeactivationBalance.toString(), 'rewarded juror deactivation balance does not match')
+            })
+
+            it('slashes the active balances of the not rewarded jurors', async () => {
+              const [firstJurorPreviousActiveBalance, firstJurorPreviousAvailableBalance, firstJurorPreviousLockedBalance, firstJurorPreviousDeactivationBalance] = await registry.balanceOf(juror)
+              const [thirdJurorPreviousActiveBalance, thirdJurorPreviousAvailableBalance, thirdJurorPreviousLockedBalance, thirdJurorPreviousDeactivationBalance] = await registry.balanceOf(thirdJuror)
+
+              await registryOwner.slashOrUnlock(jurors, lockedAmounts, rewardedJurors)
+
+              const [firstJurorCurrentActiveBalance, firstJurorCurrentAvailableBalance, firstJurorCurrentLockedBalance, firstJurorCurrentDeactivationBalance] = await registry.balanceOf(juror)
+              assert.equal(firstJurorPreviousLockedBalance.minus(DRAFT_LOCK_AMOUNT.mul(3)).toString(), firstJurorCurrentLockedBalance.toString(), 'first slashed juror locked balance does not match')
+              assert.equal(firstJurorPreviousActiveBalance.minus(DRAFT_LOCK_AMOUNT.mul(3)).toString(), firstJurorCurrentActiveBalance.toString(), 'first slashed juror active balance does not match')
+              assert.equal(firstJurorPreviousAvailableBalance.toString(), firstJurorCurrentAvailableBalance.toString(), 'first slashed juror available balance does not match')
+              assert.equal(firstJurorPreviousDeactivationBalance.toString(), firstJurorCurrentDeactivationBalance.toString(), 'first slashed juror deactivation balance does not match')
+
+              const [thirdJurorCurrentActiveBalance, thirdJurorCurrentAvailableBalance, thirdJurorCurrentLockedBalance, thirdJurorCurrentDeactivationBalance] = await registry.balanceOf(thirdJuror)
+              assert.equal(thirdJurorPreviousLockedBalance.minus(DRAFT_LOCK_AMOUNT.mul(6)).toString(), thirdJurorCurrentLockedBalance.toString(), 'second slashed juror locked balance does not match')
+              assert.equal(thirdJurorPreviousActiveBalance.minus(DRAFT_LOCK_AMOUNT.mul(6)).toString(), thirdJurorCurrentActiveBalance.toString(), 'second slashed juror active balance does not match')
+              assert.equal(thirdJurorPreviousAvailableBalance.toString(), thirdJurorCurrentAvailableBalance.toString(), 'second slashed juror available balance does not match')
+              assert.equal(thirdJurorPreviousDeactivationBalance.toString(), thirdJurorCurrentDeactivationBalance.toString(), 'second slashed juror deactivation balance does not match')
+            })
+
+            it('does not affect the active balances of the current term', async () => {
+              let termId = await registryOwner.getLastEnsuredTermId();
+              const firstJurorPreviousActiveBalance = await registry.activeBalanceOfAt(juror, termId)
+              const secondJurorPreviousActiveBalance = await registry.activeBalanceOfAt(secondJuror, termId)
+              const thirdJurorPreviousActiveBalance = await registry.activeBalanceOfAt(thirdJuror, termId)
+
+              await registryOwner.slashOrUnlock(jurors, lockedAmounts, rewardedJurors)
+
+              const firstJurorCurrentActiveBalance = await registry.activeBalanceOfAt(juror, termId)
+              assert.equal(firstJurorPreviousActiveBalance.toString(), firstJurorCurrentActiveBalance.toString(), 'first juror active balance does not match')
+
+              const secondJurorCurrentActiveBalance = await registry.activeBalanceOfAt(secondJuror, termId)
+              assert.equal(secondJurorPreviousActiveBalance.toString(), secondJurorCurrentActiveBalance.toString(), 'second juror active balance does not match')
+
+              const thirdJurorCurrentActiveBalance = await registry.activeBalanceOfAt(thirdJuror, termId)
+              assert.equal(thirdJurorPreviousActiveBalance.toString(), thirdJurorCurrentActiveBalance.toString(), 'third juror active balance does not match')
+            })
+          })
+
+          context('when given lock amounts are not valid', () => {
+            const lockedAmounts = [DRAFT_LOCK_AMOUNT.mul(10), 0, 0]
+
+            it('reverts', async () => {
+              await assertRevert(registryOwner.slashOrUnlock(jurors, lockedAmounts, rewardedJurors), 'MATH_SUB_UNDERFLOW')
+            })
+          })
+        })
+      })
+
+      context('when the sender is not the owner', () => {
+        it('reverts', async () => {
+          await assertRevert(registry.slashOrUnlock(0, [], [], []), 'JR_SENDER_NOT_OWNER')
+        })
+      })
+    })
+
+    context('when the registry is not initialized', () => {
+      it('reverts', async () => {
+        await assertRevert(registryOwner.slashOrUnlock([], [], []), 'JR_SENDER_NOT_OWNER')
+      })
+    })
   })
 
   describe('collectTokens', () => {

--- a/test/registry/jurors-registry-slashing.js
+++ b/test/registry/jurors-registry-slashing.js
@@ -103,12 +103,12 @@ contract('JurorsRegistry slashing', ([_, juror, secondJuror, thirdJuror, anyone]
           context('when given lock amounts are valid', () => {
             const lockedAmounts = [DRAFT_LOCK_AMOUNT.mul(3), DRAFT_LOCK_AMOUNT, DRAFT_LOCK_AMOUNT.mul(6)]
 
-            it('collect tokens the slashed amounts', async () => {
+            it('collect tokens for all the slashed amounts', async () => {
               const receipt = await registryOwner.slashOrUnlock(jurors, lockedAmounts, rewardedJurors)
               assertEvent(receipt, 'Slashed', { collected: DRAFT_LOCK_AMOUNT.mul(9) })
             })
 
-            it('reimburses the lock balances of the rewarded jurors', async () => {
+            it('unlocks balances of the rewarded jurors', async () => {
               const [previousActiveBalance, previousAvailableBalance, previousLockedBalance, previousDeactivationBalance] = await registry.balanceOf(secondJuror)
 
               await registryOwner.slashOrUnlock(jurors, lockedAmounts, rewardedJurors)
@@ -140,7 +140,7 @@ contract('JurorsRegistry slashing', ([_, juror, secondJuror, thirdJuror, anyone]
             })
 
             it('does not affect the active balances of the current term', async () => {
-              let termId = await registryOwner.getLastEnsuredTermId();
+              let termId = await registryOwner.getLastEnsuredTermId()
               const firstJurorPreviousActiveBalance = await registry.activeBalanceOfAt(juror, termId)
               const secondJurorPreviousActiveBalance = await registry.activeBalanceOfAt(secondJuror, termId)
               const thirdJurorPreviousActiveBalance = await registry.activeBalanceOfAt(thirdJuror, termId)

--- a/test/tree/hex-sum-tree-gas.js
+++ b/test/tree/hex-sum-tree-gas.js
@@ -181,7 +181,7 @@ contract('HexSumTree', () => {
       context('searching one item', () => {
         context('small tree', () => {
           context('without checkpoints', () => {
-            const expectedCost = 6e3
+            const expectedCost = 9e3
 
             itCostsAtMost(expectedCost, async () => {
               await tree.insert(0, value)
@@ -192,7 +192,7 @@ contract('HexSumTree', () => {
 
           context('with checkpoints', () => {
             const updateTimes = 100
-            const expectedCost = 13e3
+            const expectedCost = 23e3
 
             itCostsAtMost(expectedCost, async () => {
               await tree.insert(0, value)
@@ -219,7 +219,7 @@ contract('HexSumTree', () => {
 
           context('with checkpoints', () => {
             const updateTimes = 100
-            const expectedCost = 28e4
+            const expectedCost = 29e4
 
             itCostsAtMost(expectedCost, async () => {
               // mock huge next key
@@ -247,7 +247,7 @@ contract('HexSumTree', () => {
 
         context('small tree', () => {
           context('without checkpoints', () => {
-            const expectedCost = 22e3
+            const expectedCost = 26e3
 
             itCostsAtMost(expectedCost, async () => {
               await insertMany(value, insertTimes)
@@ -258,7 +258,7 @@ contract('HexSumTree', () => {
 
           context('with checkpoints', () => {
             const updateTimes = 100
-            const expectedCost = 32e3
+            const expectedCost = 42e3
 
             itCostsAtMost(expectedCost, async () => {
               await insertMany(value, insertTimes)
@@ -285,7 +285,7 @@ contract('HexSumTree', () => {
 
           context('with checkpoints', () => {
             const updateTimes = 100
-            const expectedCost = 98e4
+            const expectedCost = 102e4
 
             itCostsAtMost(expectedCost, async () => {
               // mock huge next key

--- a/test/tree/hex-sum-tree.js
+++ b/test/tree/hex-sum-tree.js
@@ -399,6 +399,7 @@ contract('HexSumTree', () => {
           })
 
           it('reverts', async () => {
+            await assertRevert(tree.update(key, time + 1, 1, true), 'CHECKPOINT_VALUE_TOO_BIG')
             await assertRevert(tree.update(key, time + 1, MAX_UINT256, true), 'SUM_TREE_UPDATE_OVERFLOW')
             await assertRevert(tree.update(key, time + 1, MAX_UINT256, false), 'CHECKPOINT_VALUE_TOO_BIG')
           })
@@ -632,7 +633,7 @@ contract('HexSumTree', () => {
     })
   })
 
-  describe('search', () => {
+  describe.only('search', () => {
     const insertTime = 10
 
     beforeEach('init tree', async () => {
@@ -644,14 +645,8 @@ contract('HexSumTree', () => {
       const searchValues = [value]
 
       context('when there was no value inserted in the tree', async () => {
-        it('returns zero', async () => {
-          const [keys, values] = await tree.search(searchValues, insertTime)
-
-          assert.equal(keys.length, 1, 'result keys length does not match')
-          assert.equal(values.length, 1, 'result values length does not match')
-
-          assert.equal(keys[0].toString(), 0, 'result key does not match')
-          assert.equal(values[0].toString(), 0, 'result value does not match')
+        it('reverts', async () => {
+          await assertRevert(tree.search(searchValues, insertTime), 'SUM_TREE_SEARCH_OUT_OF_BOUNDS')
         })
       })
 
@@ -664,28 +659,16 @@ contract('HexSumTree', () => {
           context('when there is no value registered for the given time', async () => {
             const searchTime = insertTime - 1
 
-            it('returns zero', async () => {
-              const [keys, values] = await tree.search(searchValues, searchTime)
-
-              assert.equal(keys.length, 1, 'result keys length does not match')
-              assert.equal(values.length, 1, 'result values length does not match')
-
-              assert.equal(keys[0].toString(), 0, 'result key does not match')
-              assert.equal(values[0].toString(), 0, 'result value does not match')
+            it('reverts', async () => {
+              await assertRevert(tree.search(searchValues, searchTime), 'SUM_TREE_SEARCH_OUT_OF_BOUNDS')
             })
           })
 
           context('when there is a value registered for the given time', async () => {
             const searchTime = insertTime
 
-            it('returns zero', async () => {
-              const [keys, values] = await tree.search(searchValues, searchTime)
-
-              assert.equal(keys.length, 1, 'result keys length does not match')
-              assert.equal(values.length, 1, 'result values length does not match')
-
-              assert.equal(keys[0].toString(), 0, 'result key does not match')
-              assert.equal(values[0].toString(), 0, 'result value does not match')
+            it('reverts', async () => {
+              await assertRevert(tree.search(searchValues, searchTime), 'SUM_TREE_SEARCH_OUT_OF_BOUNDS')
             })
           })
         })
@@ -698,14 +681,8 @@ contract('HexSumTree', () => {
           context('when there is no value registered for the given time', async () => {
             const searchTime = insertTime - 1
 
-            it('returns zero', async () => {
-              const [keys, values] = await tree.search(searchValues, searchTime)
-
-              assert.equal(keys.length, 1, 'result keys length does not match')
-              assert.equal(values.length, 1, 'result values length does not match')
-
-              assert.equal(keys[0].toString(), 0, 'result key does not match')
-              assert.equal(values[0].toString(), 0, 'result value does not match')
+            it('reverts', async () => {
+              await assertRevert(tree.search(searchValues, searchTime), 'SUM_TREE_SEARCH_OUT_OF_BOUNDS')
             })
           })
 
@@ -732,21 +709,14 @@ contract('HexSumTree', () => {
           context('when there is no value registered for the given time', async () => {
             const searchTime = insertTime - 1
 
-            it('returns zero', async () => {
-              const [keys, values] = await tree.search(searchValues, searchTime)
-
-              assert.equal(keys.length, 1, 'result keys length does not match')
-              assert.equal(values.length, 1, 'result values length does not match')
-
-              assert.equal(keys[0].toString(), 0, 'result key does not match')
-              assert.equal(values[0].toString(), 0, 'result value does not match')
+            it('reverts', async () => {
+              await assertRevert(tree.search(searchValues, searchTime), 'SUM_TREE_SEARCH_OUT_OF_BOUNDS')
             })
           })
 
           context('when there is a value registered for the given time', async () => {
             const searchTime = insertTime
 
-            // TODO: this scenario is not passing but it should
             it('returns the first item', async () => {
               const [keys, values] = await tree.search(searchValues, searchTime)
 
@@ -762,12 +732,12 @@ contract('HexSumTree', () => {
 
       context('when there were many values inserted in the tree', async () => {
         context('when the total does not reach the searched value', async () => {
-          beforeEach('insert value', async () => {
-            await tree.insert(insertTime, 3)
-            await tree.insert(insertTime, 4)
-            await tree.insert(insertTime, 2)
-            await tree.insert(insertTime, 1)
-            await tree.insert(insertTime, 2)
+          const insertedItems = [3, 4, 2, 1, 2]
+
+          beforeEach('insert values', async () => {
+            for (let i = 0; i < insertedItems.length; i++) {
+              await tree.insert(insertTime, insertedItems[i])
+            }
 
             assert.isAbove(value, (await tree.totalAt(insertTime)).toNumber(), 'tree total does not match')
           })
@@ -775,40 +745,27 @@ contract('HexSumTree', () => {
           context('when there is no value registered for the given time', async () => {
             const searchTime = insertTime - 1
 
-            it('returns zero', async () => {
-              const [keys, values] = await tree.search(searchValues, searchTime)
-
-              assert.equal(keys.length, 1, 'result keys length does not match')
-              assert.equal(values.length, 1, 'result values length does not match')
-
-              assert.equal(keys[0].toString(), 0, 'result key does not match')
-              assert.equal(values[0].toString(), 0, 'result value does not match')
+            it('reverts', async () => {
+              await assertRevert(tree.search(searchValues, searchTime), 'SUM_TREE_SEARCH_OUT_OF_BOUNDS')
             })
           })
 
           context('when there is a value registered for the given time', async () => {
             const searchTime = insertTime
 
-            it('returns zero', async () => {
-              const [keys, values] = await tree.search(searchValues, searchTime)
-
-              assert.equal(keys.length, 1, 'result keys length does not match')
-              assert.equal(values.length, 1, 'result values length does not match')
-
-              assert.equal(keys[0].toString(), 0, 'result key does not match')
-              assert.equal(values[0].toString(), 0, 'result value does not match')
+            it('reverts', async () => {
+              await assertRevert(tree.search(searchValues, searchTime), 'SUM_TREE_SEARCH_OUT_OF_BOUNDS')
             })
           })
         })
 
         context('when the total is equal to the searched value', async () => {
+          const insertedItems = [3, 4, 2, 1, 2, 3]
+
           beforeEach('insert values', async () => {
-            await tree.insert(insertTime, 3)
-            await tree.insert(insertTime, 4)
-            await tree.insert(insertTime, 2)
-            await tree.insert(insertTime, 1)
-            await tree.insert(insertTime, 2)
-            await tree.insert(insertTime, 3)
+            for (let i = 0; i < insertedItems.length; i++) {
+              await tree.insert(insertTime, insertedItems[i])
+            }
 
             assert.equal((await tree.totalAt(insertTime)).toString(), value, 'tree total does not match')
           })
@@ -816,14 +773,8 @@ contract('HexSumTree', () => {
           context('when there is no value registered for the given time', async () => {
             const searchTime = insertTime - 1
 
-            it('returns zero', async () => {
-              const [keys, values] = await tree.search(searchValues, searchTime)
-
-              assert.equal(keys.length, 1, 'result keys length does not match')
-              assert.equal(values.length, 1, 'result values length does not match')
-
-              assert.equal(keys[0].toString(), 0, 'result key does not match')
-              assert.equal(values[0].toString(), 0, 'result value does not match')
+            it('reverts', async () => {
+              await assertRevert(tree.search(searchValues, searchTime), 'SUM_TREE_SEARCH_OUT_OF_BOUNDS')
             })
           })
 
@@ -843,16 +794,12 @@ contract('HexSumTree', () => {
         })
 
         context('when the total is greater than the searched value', async () => {
+          const insertedItems = [3, 4, 2, 1, 2, 4, 5, 8, 1]
+
           beforeEach('insert values', async () => {
-            await tree.insert(insertTime, 3)
-            await tree.insert(insertTime, 4)
-            await tree.insert(insertTime, 2)
-            await tree.insert(insertTime, 1)
-            await tree.insert(insertTime, 2)
-            await tree.insert(insertTime, 4)
-            await tree.insert(insertTime, 5)
-            await tree.insert(insertTime, 8)
-            await tree.insert(insertTime, 1)
+            for (let i = 0; i < insertedItems.length; i++) {
+              await tree.insert(insertTime, insertedItems[i])
+            }
 
             assert.isAtMost(value, (await tree.totalAt(insertTime)).toNumber(), 'tree total does not match')
           })
@@ -860,14 +807,8 @@ contract('HexSumTree', () => {
           context('when there is no value registered for the given time', async () => {
             const searchTime = insertTime - 1
 
-            it('returns zero', async () => {
-              const [keys, values] = await tree.search(searchValues, searchTime)
-
-              assert.equal(keys.length, 1, 'result keys length does not match')
-              assert.equal(values.length, 1, 'result values length does not match')
-
-              assert.equal(keys[0].toString(), 0, 'result key does not match')
-              assert.equal(values[0].toString(), 0, 'result value does not match')
+            it('reverts', async () => {
+              await assertRevert(tree.search(searchValues, searchTime), 'SUM_TREE_SEARCH_OUT_OF_BOUNDS')
             })
           })
 
@@ -881,7 +822,7 @@ contract('HexSumTree', () => {
               assert.equal(values.length, 1, 'result values length does not match')
 
               assert.equal(keys[0].toString(), 5, 'result key does not match')
-              assert.equal(values[0].toString(), 4, 'result value does not match')
+              assert.equal(values[0].toString(), insertedItems[5], 'result value does not match')
             })
           })
         })
@@ -892,16 +833,12 @@ contract('HexSumTree', () => {
       context('without checkpointing', async () => {
         context('when all values are included in the tree', () => {
           const searchValues = [1, 5, 8, 18, 22]
+          const insertedItems = [2, 1, 4, 1, 8, 6, 7, 1]
 
           beforeEach('insert values', async () => {
-            await tree.insert(insertTime, 2) // 2
-            await tree.insert(insertTime, 1) // 3
-            await tree.insert(insertTime, 4) // 7
-            await tree.insert(insertTime, 1) // 8
-            await tree.insert(insertTime, 8) // 16
-            await tree.insert(insertTime, 6) // 22
-            await tree.insert(insertTime, 7) // 29
-            await tree.insert(insertTime, 1) // 30
+            for (let i = 0; i < insertedItems.length; i++) {
+              await tree.insert(insertTime, insertedItems[i])
+            }
 
             assert.isAtMost(searchValues[searchValues.length - 1], (await tree.totalAt(insertTime)).toNumber(), 'tree total does not match')
           })
@@ -909,26 +846,8 @@ contract('HexSumTree', () => {
           context('when there is no value registered for the given time', async () => {
             const searchTime = insertTime - 1
 
-            it('returns zero', async () => {
-              const [keys, values] = await tree.search(searchValues, searchTime)
-
-              assert.equal(keys.length, searchValues.length, 'result keys length does not match')
-              assert.equal(values.length, searchValues.length, 'result values length does not match')
-
-              assert.equal(keys[0].toString(), 0, 'first result key does not match')
-              assert.equal(values[0].toString(), 0, 'first result value does not match')
-
-              assert.equal(keys[1].toString(), 0, 'second result key does not match')
-              assert.equal(values[1].toString(), 0, 'second result value does not match')
-
-              assert.equal(keys[2].toString(), 0, 'third result key does not match')
-              assert.equal(values[2].toString(), 0, 'third result value does not match')
-
-              assert.equal(keys[3].toString(), 0, 'fourth result key does not match')
-              assert.equal(values[3].toString(), 0, 'fourth result value does not match')
-
-              assert.equal(keys[4].toString(), 0, 'fifth result key does not match')
-              assert.equal(values[4].toString(), 0, 'fifth result value does not match')
+            it('reverts', async () => {
+              await assertRevert(tree.search(searchValues, searchTime), 'SUM_TREE_SEARCH_OUT_OF_BOUNDS')
             })
           })
 
@@ -942,92 +861,46 @@ contract('HexSumTree', () => {
               assert.equal(values.length, searchValues.length, 'result values length does not match')
 
               assert.equal(keys[0].toString(), 0, 'first result key does not match')
-              assert.equal(values[0].toString(), 2, 'first result value does not match')
+              assert.equal(values[0].toString(), insertedItems[0], 'first result value does not match')
 
               assert.equal(keys[1].toString(), 2, 'second result key does not match')
-              assert.equal(values[1].toString(), 4, 'second result value does not match')
+              assert.equal(values[1].toString(), insertedItems[2], 'second result value does not match')
 
               assert.equal(keys[2].toString(), 3, 'third result key does not match')
-              assert.equal(values[2].toString(), 1, 'third result value does not match')
+              assert.equal(values[2].toString(), insertedItems[3], 'third result value does not match')
 
               assert.equal(keys[3].toString(), 5, 'fourth result key does not match')
-              assert.equal(values[3].toString(), 6, 'fourth result value does not match')
+              assert.equal(values[3].toString(), insertedItems[5], 'fourth result value does not match')
 
               assert.equal(keys[4].toString(), 5, 'fifth result key does not match')
-              assert.equal(values[4].toString(), 6, 'fifth result value does not match')
+              assert.equal(values[4].toString(), insertedItems[5], 'fifth result value does not match')
             })
           })
         })
 
         context('when some values are not included in the tree', () => {
           const searchValues = [1, 5, 8, 18, 22, 31]
+          const insertedItems = [2, 1, 4, 1, 8, 6, 7, 1]
 
           beforeEach('insert values', async () => {
-            await tree.insert(insertTime, 2) // 2
-            await tree.insert(insertTime, 1) // 3
-            await tree.insert(insertTime, 4) // 7
-            await tree.insert(insertTime, 1) // 8
-            await tree.insert(insertTime, 8) // 16
-            await tree.insert(insertTime, 6) // 22
-            await tree.insert(insertTime, 7) // 29
-            await tree.insert(insertTime, 1) // 30
+            for (let i = 0; i < insertedItems.length; i++) {
+              await tree.insert(insertTime, insertedItems[i])
+            }
           })
 
           context('when there is no value registered for the given time', async () => {
             const searchTime = insertTime - 1
 
-            it('returns zero', async () => {
-              const [keys, values] = await tree.search(searchValues, searchTime)
-
-              assert.equal(keys.length, searchValues.length, 'result keys length does not match')
-              assert.equal(values.length, searchValues.length, 'result values length does not match')
-
-              assert.equal(keys[0].toString(), 0, 'first result key does not match')
-              assert.equal(values[0].toString(), 0, 'first result value does not match')
-
-              assert.equal(keys[1].toString(), 0, 'second result key does not match')
-              assert.equal(values[1].toString(), 0, 'second result value does not match')
-
-              assert.equal(keys[2].toString(), 0, 'third result key does not match')
-              assert.equal(values[2].toString(), 0, 'third result value does not match')
-
-              assert.equal(keys[3].toString(), 0, 'fourth result key does not match')
-              assert.equal(values[3].toString(), 0, 'fourth result value does not match')
-
-              assert.equal(keys[4].toString(), 0, 'fifth result key does not match')
-              assert.equal(values[4].toString(), 0, 'fifth result value does not match')
-
-              assert.equal(keys[5].toString(), 0, 'sixth result key does not match')
-              assert.equal(values[5].toString(), 0, 'sixth result value does not match')
+            it('reverts', async () => {
+              await assertRevert(tree.search(searchValues, searchTime), 'SUM_TREE_SEARCH_OUT_OF_BOUNDS')
             })
           })
 
           context('when there is a value registered for the given time', async () => {
             const searchTime = insertTime
 
-            it('returns the expected items', async () => {
-              const [keys, values] = await tree.search(searchValues, searchTime)
-
-              assert.equal(keys.length, searchValues.length, 'result keys length does not match')
-              assert.equal(values.length, searchValues.length, 'result values length does not match')
-
-              assert.equal(keys[0].toString(), 0, 'first result key does not match')
-              assert.equal(values[0].toString(), 2, 'first result value does not match')
-
-              assert.equal(keys[1].toString(), 2, 'second result key does not match')
-              assert.equal(values[1].toString(), 4, 'second result value does not match')
-
-              assert.equal(keys[2].toString(), 3, 'third result key does not match')
-              assert.equal(values[2].toString(), 1, 'third result value does not match')
-
-              assert.equal(keys[3].toString(), 5, 'fourth result key does not match')
-              assert.equal(values[3].toString(), 6, 'fourth result value does not match')
-
-              assert.equal(keys[4].toString(), 5, 'fifth result key does not match')
-              assert.equal(values[4].toString(), 6, 'fifth result value does not match')
-
-              assert.equal(keys[5].toString(), 0, 'sixth result key does not match')
-              assert.equal(values[5].toString(), 0, 'sixth result value does not match')
+            it('reverts', async () => {
+              await assertRevert(tree.search(searchValues, searchTime), 'SUM_TREE_SEARCH_OUT_OF_BOUNDS')
             })
           })
         })

--- a/test/tree/hex-sum-tree.js
+++ b/test/tree/hex-sum-tree.js
@@ -633,7 +633,7 @@ contract('HexSumTree', () => {
     })
   })
 
-  describe.only('search', () => {
+  describe('search', () => {
     const insertTime = 10
 
     beforeEach('init tree', async () => {

--- a/test/tree/hex-sum-tree.js
+++ b/test/tree/hex-sum-tree.js
@@ -95,7 +95,7 @@ contract('HexSumTree', () => {
         beforeEach('insert 40 values', async () => {
           // First 16 set of children will be         1^0, 1^1, 1^2, ..., 1^15 at time i+1
           // Second 16 set of children will be        2^0, 2^1, 2^2, ..., 2^15 at time i+1
-          // Final 8 set of remaining values will be  3^0, 3^1, 3^2, ..., 3^8  at time i+1
+          // Final 8 set of remaining values will be  3^0, 3^1, 3^2, ..., 3^7  at time i+1
 
           for(let key = 0; key < 40; key++) {
             const time = key + 1
@@ -265,7 +265,7 @@ contract('HexSumTree', () => {
         beforeEach('insert and set 40 values', async () => {
           // First 16 set of children will be         1^0, 1^1, 1^2, ..., 1^15 at time 2
           // Second 16 set of children will be        2^0, 2^1, 2^2, ..., 2^15 at time 2
-          // Final 8 set of remaining values will be  3^0, 3^1, 3^2, ..., 3^8  at time 2
+          // Final 8 set of remaining values will be  3^0, 3^1, 3^2, ..., 3^7 at time 2
           // All values will be incremented by 1 at time 5
 
           for(let key = 0; key < 40; key++) await tree.insert(insertionTime, value(key))
@@ -529,7 +529,7 @@ contract('HexSumTree', () => {
           beforeEach('insert and update 40 values', async () => {
             // First 16 set of children will be         1^0, 1^1, 1^2, ..., 1^15 at time 2
             // Second 16 set of children will be        2^0, 2^1, 2^2, ..., 2^15 at time 2
-            // Final 8 set of remaining values will be  3^0, 3^1, 3^2, ..., 3^8  at time 2
+            // Final 8 set of remaining values will be  3^0, 3^1, 3^2, ..., 3^7  at time 2
             // All values will be incremented or decremented by 1 at time 5
 
             for(let key = 0; key < 40; key++) await tree.insert(insertionTime, value(key))

--- a/test/tree/jurors-tree-sortition.js
+++ b/test/tree/jurors-tree-sortition.js
@@ -8,7 +8,7 @@ contract('JurorsTreeSortition', () => {
     await tree.init()
   })
 
-  describe('getActiveBalancesBatchBounds', () => {
+  describe('getSearchBatchBounds', () => {
     const termId = 2
     const totalRequestedJurors = 5
 
@@ -24,11 +24,11 @@ contract('JurorsTreeSortition', () => {
       const selectedJurors = 0
       const batchRequestedJurors = 2
 
-      const expectedLowBound = 0
+      const expectedLowBound = 1
       const expectedHighBound = 4
 
       it('includes the first juror', async () => {
-        const [low, high] = await tree.getActiveBalancesBatchBounds(termId, selectedJurors, batchRequestedJurors, totalRequestedJurors)
+        const [low, high] = await tree.getSearchBatchBounds(termId, selectedJurors, batchRequestedJurors, totalRequestedJurors)
 
         assert.equal(low.toString(), expectedLowBound, 'low bound does not match')
         assert.equal(high.toString(), expectedHighBound, 'high bound does not match')
@@ -43,7 +43,7 @@ contract('JurorsTreeSortition', () => {
       const expectedHighBound = 8
 
       it('includes middle jurors', async () => {
-        const [low, high] = await tree.getActiveBalancesBatchBounds(termId, selectedJurors, batchRequestedJurors, totalRequestedJurors)
+        const [low, high] = await tree.getSearchBatchBounds(termId, selectedJurors, batchRequestedJurors, totalRequestedJurors)
 
         assert.equal(low.toString(), expectedLowBound, 'low bound does not match')
         assert.equal(high.toString(), expectedHighBound, 'high bound does not match')
@@ -58,7 +58,7 @@ contract('JurorsTreeSortition', () => {
       const expectedHighBound = 12
 
       it('includes the last juror', async () => {
-        const [low, high] = await tree.getActiveBalancesBatchBounds(termId, selectedJurors, batchRequestedJurors, totalRequestedJurors)
+        const [low, high] = await tree.getSearchBatchBounds(termId, selectedJurors, batchRequestedJurors, totalRequestedJurors)
 
         assert.equal(low.toString(), expectedLowBound, 'low bound does not match')
         assert.equal(high.toString(), expectedHighBound, 'high bound does not match')
@@ -102,7 +102,7 @@ contract('JurorsTreeSortition', () => {
     })
   })
 
-  describe('multiSortition', () => {
+  describe('batchedRandomSearch', () => {
     const termId = 0
     const disputeId = 0
     const sortitionIteration = 0
@@ -118,25 +118,25 @@ contract('JurorsTreeSortition', () => {
       const roundRequestedJurors = 10
 
       it('returns the expected results', async () => {
-        const [jurorIds, activeBalances] = await tree.multiSortition(termRandomness, disputeId, termId, selectedJurors, batchRequestedJurors, roundRequestedJurors, sortitionIteration)
+        const [jurorIds, activeBalances] = await tree.batchedRandomSearch(termRandomness, disputeId, termId, selectedJurors, batchRequestedJurors, roundRequestedJurors, sortitionIteration)
 
         assert.equal(jurorIds.length, batchRequestedJurors, 'result keys length does not match')
         assert.equal(activeBalances.length, batchRequestedJurors, 'result values length does not match')
 
-        assert.equal(jurorIds[0].toString(), 41, 'first result key does not match')
-        assert.equal(activeBalances[0].toString(), 41, 'first result value does not match')
+        assert.equal(jurorIds[0].toString(), 35, 'first result key does not match')
+        assert.equal(activeBalances[0].toString(), 35, 'first result value does not match')
 
-        assert.equal(jurorIds[1].toString(), 55, 'second result key does not match')
-        assert.equal(activeBalances[1].toString(), 55, 'second result value does not match')
+        assert.equal(jurorIds[1].toString(), 38, 'second result key does not match')
+        assert.equal(activeBalances[1].toString(), 38, 'second result value does not match')
 
-        assert.equal(jurorIds[2].toString(), 60, 'third result key does not match')
-        assert.equal(activeBalances[2].toString(), 60, 'third result value does not match')
+        assert.equal(jurorIds[2].toString(), 38, 'third result key does not match')
+        assert.equal(activeBalances[2].toString(), 38, 'third result value does not match')
 
-        assert.equal(jurorIds[3].toString(), 69, 'fourth result key does not match')
-        assert.equal(activeBalances[3].toString(), 69, 'fourth result value does not match')
+        assert.equal(jurorIds[3].toString(), 68, 'fourth result key does not match')
+        assert.equal(activeBalances[3].toString(), 68, 'fourth result value does not match')
 
-        assert.equal(jurorIds[4].toString(), 70, 'fifth result key does not match')
-        assert.equal(activeBalances[4].toString(), 70, 'fifth result value does not match')
+        assert.equal(jurorIds[4].toString(), 68, 'fifth result key does not match')
+        assert.equal(activeBalances[4].toString(), 68, 'fifth result value does not match')
       })
     })
 
@@ -146,7 +146,7 @@ contract('JurorsTreeSortition', () => {
       const roundRequestedJurors = 10
 
       it('returns the expected results', async () => {
-        const [jurorIds, activeBalances] = await tree.multiSortition(termRandomness, disputeId, termId, selectedJurors, batchRequestedJurors, roundRequestedJurors, sortitionIteration)
+        const [jurorIds, activeBalances] = await tree.batchedRandomSearch(termRandomness, disputeId, termId, selectedJurors, batchRequestedJurors, roundRequestedJurors, sortitionIteration)
 
         assert.equal(jurorIds.length, batchRequestedJurors, 'result keys length does not match')
         assert.equal(activeBalances.length, batchRequestedJurors, 'result values length does not match')


### PR DESCRIPTION
**MERGE AFTER #104**

Fixes #85 

🚨Something to bear in mind and keep analyzing is that the drafting process executes a loop that may not end, producing an OOG error. We could try avoiding the multi-sortitions iterations having a check of the locked balances within the sortition itself.