### PR TITLE
Remove voteExists modifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@aragon/apps-shared-migrations": "^1.0.0",
     "@aragon/test-helpers": "^2.0.0",
+    "eth-gas-reporter": "^0.2.9",
     "ganache-cli": "^6.1.0",
     "solidity-coverage": "0.5.8",
     "solium": "^1.2.3",


### PR DESCRIPTION
Gas compariosn.

- Before:

|  Contract           |  Method             |  Min        |  Max        |  Avg         |  # calls     |  usd (avg)  
|---------------------|---------------------|-------------|-------------|--------------|--------------|-------------
|  CRVoting           |  commit             |      50113  |      50241  |       50215  |         398  |       0.03  
|  CRVoting           |  init               |      63937  |      64001  |       63998  |         201  |       0.03  
|  CRVoting           |  leak               |      53245  |      53309  |       53291  |          64  |       0.03  
|  CRVoting           |  reveal             |      58593  |      78820  |       71970  |         238  |       0.04  
|  CRVotingOwnerMock  |  create             |      47156  |      47220  |       47160  |         195  |       0.03  
|  CRVotingOwnerMock  |  mockChecksFailing  |          -  |          -  |       27078  |          13  |       0.01  
|  CRVotingOwnerMock  |  mockVoterWeight    |      14369  |      43801  |       41454  |         581  |       0.02  

|  Deployments                              |  Min        |  Max        |  Avg         |  % of limit  |  usd (avg)  
|-------------------------------------------|-------------|-------------|--------------|--------------|-------------
|  CRVoting                                 |          -  |          -  |     1702692  |      21.3 %  |       0.91  
|  CRVotingOwnerMock                        |     293401  |     293529  |      293523  |       3.7 %  |       0.16  

- After:

|  Contract           |  Method             |  Min        |  Max        |  Avg         |  # calls     |  usd (avg)  
|---------------------|---------------------|-------------|-------------|--------------|--------------|-------------
|  CRVoting           |  commit             |      50079  |      50207  |       50181  |         398  |       0.03  
|  CRVoting           |  init               |      63937  |      64001  |       63998  |         201  |       0.03  
|  CRVoting           |  leak               |      53202  |      53266  |       53256  |          64  |       0.03  
|  CRVoting           |  reveal             |      58531  |      78758  |       71908  |         238  |       0.04  
|  CRVotingOwnerMock  |  create             |      47152  |      47216  |       47156  |         195  |       0.03  
|  CRVotingOwnerMock  |  mockChecksFailing  |          -  |          -  |       27078  |          13  |       0.01  
|  CRVotingOwnerMock  |  mockVoterWeight    |      14369  |      43801  |       41461  |         581  |       0.02  

|  Deployments                              |  Min        |  Max        |  Avg         |  % of limit  |  usd (avg)  
|-------------------------------------------|-------------|-------------|--------------|--------------|-------------
|  CRVoting                                 |          -  |          -  |     1333930  |      16.7 %  |       0.72  
|  CRVotingOwnerMock                        |     293465  |     293529  |      293526  |       3.7 %  |       0.16  

The bytecode size goes down from 6216 to 4833.
