### PR TITLE
Tree: Add gas profiling scripts

### DIFF
--- a/contracts/test/tree/HexSumTreeGasProfiler.sol
+++ b/contracts/test/tree/HexSumTreeGasProfiler.sol
@@ -8,7 +8,9 @@ contract HexSumTreeGasProfiler is TimeHelpersMock {
     using HexSumTree for HexSumTree.Tree;
     using Checkpointing for Checkpointing.History;
 
+    uint256 private constant BASE_KEY = 0;
     uint256 private constant CHILDREN = 16;
+    uint256 private constant ITEMS_LEVEL = 0;
     uint256 private constant BITS_IN_NIBBLE = 4;
 
     HexSumTree.Tree internal tree;
@@ -53,7 +55,15 @@ contract HexSumTreeGasProfiler is TimeHelpersMock {
         tree.height.add(_time, newHeight);
     }
 
+    function nextKey() external view returns (uint256) {
+        return tree.nextKey;
+    }
+
     function height() external view returns (uint256) {
         return tree.getHeight();
+    }
+
+    function total() public view returns (uint256) {
+        return tree.getTotal();
     }
 }

--- a/scripts/tree-profile-gas.js
+++ b/scripts/tree-profile-gas.js
@@ -90,33 +90,43 @@ const logTreeState = async (tree) => {
 }
 
 const logInsertStats = (title, gasCosts) => {
-  const COL_SIZE = 8
-  const min = (k) => Math.min(...gasCosts.map(x => x[k]))
-  const max = (k) => Math.max(...gasCosts.map(x => x[k]))
-  const avg = (k) => Math.round(gasCosts.map(x => x[k]).reduce((a, b) => a + b, 0) / gasCosts.length)
+  const min = prop => Math.min(...gasCosts.map(x => x[prop])).toLocaleString()
+  const max = prop => Math.max(...gasCosts.map(x => x[prop])).toLocaleString()
+  const avg = prop => Math.round(gasCosts.map(x => x[prop]).reduce((a, b) => a + b, 0) / gasCosts.length).toLocaleString()
 
-  console.log(`\n${title}\n`)
-  console.log('|', ' '.padEnd(COL_SIZE, ' '), '|', 'Total'.padEnd(COL_SIZE, ' '), '|', 'Function'.padEnd(COL_SIZE, ' '), '|')
-  console.log('|', '-'.padEnd(COL_SIZE, '-'), '|', '-'.padEnd(COL_SIZE, '-'), '|', '-'.padEnd(COL_SIZE, '-'), '|')
-  console.log('| Min      |', formatDivision(min('total'), COL_SIZE), '|', formatDivision(min('function'), COL_SIZE), '|')
-  console.log('| Max      |', formatDivision(max('total'), COL_SIZE), '|', formatDivision(max('function'), COL_SIZE), '|')
-  console.log('| Average  |', formatDivision(avg('total'), COL_SIZE), '|', formatDivision(avg('function'), COL_SIZE), '|')
+  printTable(title, [
+    ['', 'Total', 'Function'],
+    ['Min', min('total'), min('function')],
+    ['Max', max('total'), max('function')],
+    ['Average', avg('total'), avg('function')],
+  ])
 }
 
 const logSearchStats = (title, gasCosts) => {
-  const COL_SIZE = 8
-  console.log(`\n${title}\n`)
-  console.log('|', ' '.padEnd(20, ' '), '|', 'Total'.padEnd(COL_SIZE, ' '), '|', 'Function'.padEnd(COL_SIZE, ' '), '|')
-  console.log('|', '-'.padEnd(20, '-'), '|', '-'.padEnd(COL_SIZE, '-'), '|', '-'.padEnd(COL_SIZE, '-'), '|')
+  const body = gasCosts.map((gasCost, batch) => {
+    const { total, values, function: fnCost } = gasCost
+    const batchName = `Batch ${batch} - ${values} values`
+    return [batchName, total.toLocaleString(), fnCost.toLocaleString()]
+  })
 
-  for (let batch = 0; batch < gasCosts.length; batch++) {
-    const { total, values, function: fnCost } = gasCosts[batch]
-    console.log(`| Batch ${batch} - ${values} values`.padEnd(22, ' '), '|', formatDivision(total, COL_SIZE), '|', formatDivision(fnCost, COL_SIZE), '|')
-  }
+  printTable(title, [['', 'Total', 'Function'], ...body])
 }
 
-const formatDivision = (result, colSize) => {
-  return Math.round(result).toLocaleString().padStart(colSize, ' ')
+const printTable = (title, rows) => {
+  const header = rows[0]
+  const columnsMaxLengths = rows.reduce((maxLengths, row) =>
+    row.map((cell, i) => Math.max(cell.length, maxLengths[i])),
+    header.map(() => 0)
+  )
+
+  const formattedHeader = header.map((cell, i) => cell.padEnd(columnsMaxLengths[i], ' '))
+  const formattedHeaderDiv = header.map((cell, i) => '-'.padEnd(columnsMaxLengths[i], '-'))
+  const formattedBody = rows.slice(1).map(row => row.map((cell, i) => cell.padStart(columnsMaxLengths[i], ' ')))
+
+  console.log(`\n${title}\n`)
+  console.log(`| ${formattedHeader.join(' | ')} |`)
+  console.log(`|-${formattedHeaderDiv.join('-|-')}-|`)
+  formattedBody.forEach(row => console.log(`| ${row.join(' | ')} |`))
 }
 
 module.exports = callback => {

--- a/scripts/tree-profile-gas.js
+++ b/scripts/tree-profile-gas.js
@@ -1,0 +1,127 @@
+const { bigExp } = require('../test/helpers/numbers')(web3)
+const { getEventArgument } = require('@aragon/test-helpers/events')
+
+const MAX_APPEAL_ROUNDS = 4
+const APPEAL_STEP_FACTOR = 3
+const INITIAL_JURORS_NUMBER = 3
+
+const TREE_SIZE_STEP_FACTOR = 10
+const TREE_MAX_SIZE = 10000
+
+const MIN_JUROR_BALANCE = 100
+const MAX_JUROR_BALANCE = 1000000
+
+async function profileGas() {
+  console.log(`MAX_APPEAL_ROUNDS: ${MAX_APPEAL_ROUNDS}`)
+  console.log(`APPEAL_STEP_FACTOR: ${APPEAL_STEP_FACTOR}`)
+  console.log(`INITIAL_JURORS_NUMBER: ${INITIAL_JURORS_NUMBER}`)
+  const HexSumTree = artifacts.require('HexSumTreeGasProfiler')
+
+  for (let treeSize = TREE_SIZE_STEP_FACTOR; treeSize <= TREE_MAX_SIZE; treeSize *= TREE_SIZE_STEP_FACTOR) {
+    console.log(`\n=====================================`)
+    console.log(`PROFILING TREE WITH SIZE ${treeSize}`)
+    const tree = await HexSumTree.new()
+    await insert(tree, treeSize)
+
+    for (let round = 1, jurorsNumber = INITIAL_JURORS_NUMBER; round <= MAX_APPEAL_ROUNDS; round++, jurorsNumber *= APPEAL_STEP_FACTOR) {
+      console.log(`\n------------------------------------`)
+      console.log(`ROUND #${round} - drafting ${jurorsNumber} jurors`)
+      await search(tree, jurorsNumber, round)
+    }
+  }
+}
+
+async function insert(tree, values) {
+  const insertGasCosts = []
+  for (let i = 0; i < values; i++) {
+    const balance = Math.floor(Math.random() * MAX_JUROR_BALANCE) + MIN_JUROR_BALANCE
+    const receipt = await tree.insert(0, bigExp(balance, 18))
+    insertGasCosts.push(getGas(receipt))
+  }
+
+  await logTreeState(tree)
+  logInsertStats(`${values} values inserted:`, insertGasCosts)
+}
+
+async function search(tree, jurorsNumber, batches) {
+  const searchGasCosts = []
+  const values = await computeSearchValues(tree, jurorsNumber, batches)
+
+  for (let batch = 0; batch < batches; batch++) {
+    const batchSearchValues = values[batch]
+    const receipt = await tree.search(batchSearchValues, 0)
+    searchGasCosts.push({ ...getGas(receipt), values: batchSearchValues.length })
+  }
+
+  logSearchStats(`${jurorsNumber} jurors searched in ${batches} batches:`, searchGasCosts)
+}
+
+async function computeSearchValues(tree, jurorsNumber, batches) {
+  const searchValues = []
+  const total = (await tree.total()).div(bigExp(1, 18))
+  const step = total.divToInt(jurorsNumber)
+  for (let i = 1; i <= jurorsNumber; i++) {
+    const value = step.mul(i)
+    searchValues.push(bigExp(value, 18))
+  }
+
+  const searchValuesPerBatch = []
+  const jurorsPerBatch = Math.floor(jurorsNumber / batches)
+  for (let batch = 0, batchSize = 0; batch < batches; batch++, batchSize += jurorsPerBatch) {
+    const limit = (batch === batches - 1) ? searchValues.length : batchSize + jurorsPerBatch
+    searchValuesPerBatch.push(searchValues.slice(batchSize, limit))
+  }
+  return searchValuesPerBatch
+}
+
+const getGas = receipt => {
+  const total = receipt.receipt.gasUsed
+  const functionCost = getEventArgument(receipt, 'GasConsumed', 'gas').toNumber()
+  return { total, function: functionCost }
+}
+
+const logTreeState = async (tree) => {
+  const total = await tree.total()
+  const height = await tree.height()
+  const nextKey = await tree.nextKey()
+  console.log(`\nTree height:   ${height.toString()}`)
+  console.log(`Tree next key: ${nextKey.toNumber().toLocaleString()}`)
+  console.log(`Tree total:    ${total.div(bigExp(1, 18)).toNumber().toLocaleString()} e18`)
+}
+
+const logInsertStats = (title, gasCosts) => {
+  const COL_SIZE = 8
+  const min = (k) => Math.min(...gasCosts.map(x => x[k]))
+  const max = (k) => Math.max(...gasCosts.map(x => x[k]))
+  const avg = (k) => Math.round(gasCosts.map(x => x[k]).reduce((a, b) => a + b, 0) / gasCosts.length)
+
+  console.log(`\n${title}\n`)
+  console.log('|', ' '.padEnd(COL_SIZE, ' '), '|', 'Total'.padEnd(COL_SIZE, ' '), '|', 'Function'.padEnd(COL_SIZE, ' '), '|')
+  console.log('|', '-'.padEnd(COL_SIZE, '-'), '|', '-'.padEnd(COL_SIZE, '-'), '|', '-'.padEnd(COL_SIZE, '-'), '|')
+  console.log('| Min      |', formatDivision(min('total'), COL_SIZE), '|', formatDivision(min('function'), COL_SIZE), '|')
+  console.log('| Max      |', formatDivision(max('total'), COL_SIZE), '|', formatDivision(max('function'), COL_SIZE), '|')
+  console.log('| Average  |', formatDivision(avg('total'), COL_SIZE), '|', formatDivision(avg('function'), COL_SIZE), '|')
+}
+
+const logSearchStats = (title, gasCosts) => {
+  const COL_SIZE = 8
+  console.log(`\n${title}\n`)
+  console.log('|', ' '.padEnd(20, ' '), '|', 'Total'.padEnd(COL_SIZE, ' '), '|', 'Function'.padEnd(COL_SIZE, ' '), '|')
+  console.log('|', '-'.padEnd(20, '-'), '|', '-'.padEnd(COL_SIZE, '-'), '|', '-'.padEnd(COL_SIZE, '-'), '|')
+
+  for (let batch = 0; batch < gasCosts.length; batch++) {
+    const { total, values, function: fnCost } = gasCosts[batch]
+    console.log(`| Batch ${batch} - ${values} values`.padEnd(22, ' '), '|', formatDivision(total, COL_SIZE), '|', formatDivision(fnCost, COL_SIZE), '|')
+  }
+}
+
+const formatDivision = (result, colSize) => {
+  return Math.round(result).toLocaleString().padStart(colSize, ' ')
+}
+
+module.exports = callback => {
+  profileGas()
+    .then(callback)
+    .catch(callback)
+}
+

--- a/test/court/court-settle.js
+++ b/test/court/court-settle.js
@@ -95,7 +95,7 @@ contract('Court', ([_, disputer, drafter, appealMaker, appealTaker, juror500, ju
               assertEvent(receipt, 'RulingExecuted', { disputeId, ruling: expectedFinalRuling })
             })
 
-            it('executes the associated airbitrable', async () => {
+            it('executes the associated arbitrable', async () => {
               const receipt = await court.executeRuling(disputeId)
 
               const logs = decodeEventsOfType(receipt, Arbitrable.abi, 'CourtRuling')


### PR DESCRIPTION
Fixes #118 

This PR aims to recover the scripts explored by @bingen, we discussed offline the idea of having a script to measure 4 different tree sizes (10, 100, 1000 and 10000) while drafting 4 rounds on each of them for a jurors number starting at 3 incremented by a step factor of 3. 

-----

```
MAX_APPEAL_ROUNDS: 4
APPEAL_STEP_FACTOR: 3
INITIAL_JURORS_NUMBER: 3
```

### PROFILING TREE WITH SIZE 10

Tree height:   1
Tree next key: 10
Tree total:    4,647,539 e18

10 values inserted:

|          | Total    | Function |
| -------- | -------- | -------- |
| Min      |   83,186 |   59,446 |
| Max      |  166,798 |  143,057 |
| Average  |   92,030 |   68,289 |

#### ROUND 1 - drafting 3 jurors

3 jurors searched in 1 batches:

|                      | Total    | Function |
| -------------------- | -------- | -------- |
| Batch 0 - 3 values   |   54,007 |   28,401 |

#### ROUND 2 - drafting 9 jurors

9 jurors searched in 2 batches:

|                      | Total    | Function |
| -------------------- | -------- | -------- |
| Batch 0 - 4 values   |   42,811 |   16,629 |
| Batch 1 - 5 values   |   56,295 |   29,281 |

#### ROUND 3 - drafting 27 jurors

27 jurors searched in 3 batches:

|                      | Total    | Function |
| -------------------- | -------- | -------- |
| Batch 0 - 9 values   |   45,585 |   16,203 |
| Batch 1 - 9 values   |   52,180 |   22,350 |
| Batch 2 - 9 values   |   60,642 |   30,876 |

#### ROUND 4 - drafting 81 jurors

81 jurors searched in 4 batches:

|                      | Total    | Function |
| -------------------- | -------- | -------- |
| Batch 0 - 20 values  |   54,091 |   17,925 |
| Batch 1 - 20 values  |   59,634 |   22,188 |
| Batch 2 - 20 values  |   63,796 |   26,286 |
| Batch 3 - 21 values  |   73,219 |   35,005 |

### PROFILING TREE WITH SIZE 100

Tree height:   2
Tree next key: 100
Tree total:    52,516,822 e18

100 values inserted:

|          | Total    | Function |
| -------- | -------- | -------- |
| Min      |   83,186 |   59,446 |
| Max      |  175,647 |  151,907 |
| Average  |   93,969 |   70,232 |

#### ROUND 1 - drafting 3 jurors

3 jurors searched in 1 batches:

|                      | Total    | Function |
| -------------------- | -------- | -------- |
| Batch 0 - 3 values   |  124,326 |   98,720 |

#### ROUND 2 - drafting 9 jurors

9 jurors searched in 2 batches:

|                      | Total    | Function |
| -------------------- | -------- | -------- |
| Batch 0 - 4 values   |  137,788 |  111,478 |
| Batch 1 - 5 values   |  160,500 |  133,485 |

#### ROUND 3 - drafting 27 jurors

27 jurors searched in 3 batches:

|                      | Total    | Function |
| -------------------- | -------- | -------- |
| Batch 0 - 9 values   |  111,139 |   81,309 |
| Batch 1 - 9 values   |  132,369 |  102,603 |
| Batch 2 - 9 values   |  132,469 |  102,703 |

#### ROUND 4 - drafting 81 jurors

81 jurors searched in 4 batches:

|                      | Total    | Function |
| -------------------- | -------- | -------- |
| Batch 0 - 20 values  |  107,353 |   69,842 |
| Batch 1 - 20 values  |  143,170 |  105,596 |
| Batch 2 - 20 values  |  127,892 |   90,317 |
| Batch 3 - 21 values  |  148,494 |  110,343 |

### PROFILING TREE WITH SIZE 1000

Tree height:   3
Tree next key: 1,000
Tree total:    503,187,773 e18

1000 values inserted:

|          | Total    | Function |
| -------- | -------- | -------- |
| Min      |   83,186 |   59,446 |
| Max      |  217,914 |  194,174 |
| Average  |  100,753 |   77,015 |

#### ROUND 1 - drafting 3 jurors

3 jurors searched in 1 batches:

|                      | Total    | Function |
| -------------------- | -------- | -------- |
| Batch 0 - 3 values   |  227,362 |  201,627 |

#### ROUND 2 - drafting 9 jurors

9 jurors searched in 2 batches:

|                      | Total    | Function |
| -------------------- | -------- | -------- |
| Batch 0 - 4 values   |  221,546 |  195,235 |
| Batch 1 - 5 values   |  263,083 |  235,877 |

#### ROUND 3 - drafting 27 jurors

27 jurors searched in 3 batches:

|                      | Total    | Function |
| -------------------- | -------- | -------- |
| Batch 0 - 9 values   |  391,782 |  362,015 |
| Batch 1 - 9 values   |  381,951 |  352,120 |
| Batch 2 - 9 values   |  403,139 |  372,860 |

#### ROUND 4 - drafting 81 jurors

81 jurors searched in 4 batches:

|                      | Total    | Function |
| -------------------- | -------- | -------- |
| Batch 0 - 20 values  |  614,923 |  577,348 |
| Batch 1 - 20 values  |  589,655 |  552,144 |
| Batch 2 - 20 values  |  632,850 |  594,635 |
| Batch 3 - 21 values  |  656,202 |  616,643 |

### PROFILING TREE WITH SIZE 10000

Tree height:   4
Tree next key: 10,000
Tree total:    4,974,648,351 e18

10000 values inserted:

|          | Total    | Function |
| -------- | -------- | -------- |
| Min      |   83,122 |   59,446 |
| Max      |  260,182 |  236,442 |
| Average  |  107,987 |   84,250 |

#### ROUND 1 - drafting 3 jurors

3 jurors searched in 1 batches:

|                      | Total    | Function |
| -------------------- | -------- | -------- |
| Batch 0 - 3 values   |  298,607 |  272,808 |

#### ROUND 2 - drafting 9 jurors

9 jurors searched in 2 batches:

|                      | Total    | Function |
| -------------------- | -------- | -------- |
| Batch 0 - 4 values   |  335,860 |  309,294 |
| Batch 1 - 5 values   |  403,158 |  375,823 |

#### ROUND 3 - drafting 27 jurors

27 jurors searched in 3 batches:

|                      | Total    | Function |
| -------------------- | -------- | -------- |
| Batch 0 - 9 values   |  638,555 |  608,212 |
| Batch 1 - 9 values   |  675,013 |  644,606 |
| Batch 2 - 9 values   |  680,765 |  650,358 |

#### ROUND 4 - drafting 81 jurors

81 jurors searched in 4 batches:

|                      | Total    | Function |
| -------------------- | -------- | -------- |
| Batch 0 - 20 values  | 1,090,343 | 1,051,808 |
| Batch 1 - 20 values  | 1,108,122 | 1,069,266 |
| Batch 2 - 20 values  | 1,067,905 | 1,029,114 |
| Batch 3 - 21 values  | 1,171,182 | 1,131,622 |
