### PR TITLE
Chore: Upgrade solidity-coverage to 0.7.0-beta.0

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,14 +1,6 @@
 module.exports = {
-  norpc: true,
-  compileCommand: '../node_modules/.bin/truffle compile',
-  copyPackages: [
-    '@aragon/os',
-    '@aragon/test-helpers'
-  ],
-  skipFiles: [
-    'test',
-    '@aragon/os',
-    '@aragon/test-helpers',
-  ],
-  deepSkip: true // Turn on deep skip to avoid preprocessing (e.g. removing view/pure modifiers) for skipped files
+  providerOptions: {
+    network_id: 16,
+    total_accounts: 200,
+  }
 }

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,4 +1,7 @@
 module.exports = {
+  skipFiles: [
+    'test',
+  ],
   providerOptions: {
     network_id: 16,
     total_accounts: 200,

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,5 @@ jobs:
       script: npm test test/subscriptions/*.js
       name: "Subscriptions"
     - stage: tests
-      script: npx truffle run coverage --file test/registry/*.js
+      script: npx truffle run coverage --file="test/registry/*.js"
       name: "Registry Coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,5 @@ jobs:
       script: npm test test/subscriptions/*.js
       name: "Subscriptions"
     - stage: tests
-      script: npx truffle run coverage --file="test/registry/*.js"
-      name: "Registry Coverage"
+      script: npx truffle run coverage --file="test/voting/*.js"
+      name: "Voting Coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,6 @@ jobs:
     - stage: tests
       script: npm test test/subscriptions/*.js
       name: "Subscriptions"
+    - stage: tests
+      script: npx truffle run coverage --file test/registry/*.js
+      name: "Registry Coverage"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "compile": "npx truffle compile",
     "lint": "solium --dir ./contracts",
     "test": "npm run ganache-cli:test",
-    "coverage": "SOLIDITY_COVERAGE=true npm run ganache-cli:test",
+    "coverage": "npx truffle run coverage",
     "ganache-cli:test": "./scripts/ganache-cli.sh"
   },
   "author": "Aragon Association",
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@aragon/test-helpers": "^2.0.0",
     "ganache-cli": "^6.4.5",
-    "solidity-coverage": "0.6.1",
+    "solidity-coverage": "^0.7.0-beta.0",
     "solium": "^1.2.3",
     "truffle": "^5.0.34",
     "web3": "^1.2.1",

--- a/test/helpers/assertThrow.js
+++ b/test/helpers/assertThrow.js
@@ -18,12 +18,19 @@ async function assertThrows(blockOrPromise, expectedErrorCode, expectedReason) {
 }
 
 async function assertRevert(blockOrPromise, reason) {
+  let ganacheCoreError = true;
   const error = await assertThrows(blockOrPromise, REVERT_CODE, reason)
   const errorPrefix_A = `${THROW_ERROR_PREFIX_A} ${REVERT_CODE}`
   const errorPrefix_B = `${THROW_ERROR_PREFIX_B} ${REVERT_CODE}`
 
-  if (error.message.includes(errorPrefix_A) || error.message.includes(errorPrefix_B)) {
+  if (error.message.includes(errorPrefix_A)) {
+    ganacheCoreError = false;
     error.reason = error.message.replace(errorPrefix_A, '')
+    // Truffle 5 sometimes add an extra ' -- Reason given: reason.' to the error message 🤷
+    error.reason = error.reason.replace(` -- Reason given: ${reason}.`, '').trim()
+  }
+
+  if (error.message.includes(errorPrefix_B) && ganacheCoreError){
     error.reason = error.message.replace(errorPrefix_B, '')
     // Truffle 5 sometimes add an extra ' -- Reason given: reason.' to the error message 🤷
     error.reason = error.reason.replace(` -- Reason given: ${reason}.`, '').trim()

--- a/test/helpers/assertThrow.js
+++ b/test/helpers/assertThrow.js
@@ -1,5 +1,6 @@
 const REVERT_CODE = 'revert'
-const THROW_ERROR_PREFIX = 'Returned error: VM Exception while processing transaction:'
+const THROW_ERROR_PREFIX_A = 'Returned error: VM Exception while processing transaction:'
+const THROW_ERROR_PREFIX_B = 'VM Exception while processing transaction:' // ganache-core
 
 function assertError(error, expectedErrorCode) {
   assert(error.message.search(expectedErrorCode) > -1, `Expected error code "${expectedErrorCode}" but failed with "${error}" instead.`)
@@ -18,10 +19,12 @@ async function assertThrows(blockOrPromise, expectedErrorCode, expectedReason) {
 
 async function assertRevert(blockOrPromise, reason) {
   const error = await assertThrows(blockOrPromise, REVERT_CODE, reason)
-  const errorPrefix = `${THROW_ERROR_PREFIX} ${REVERT_CODE}`
+  const errorPrefix_A = `${THROW_ERROR_PREFIX_A} ${REVERT_CODE}`
+  const errorPrefix_B = `${THROW_ERROR_PREFIX_B} ${REVERT_CODE}`
 
-  if (error.message.includes(errorPrefix)) {
-    error.reason = error.message.replace(errorPrefix, '')
+  if (error.message.includes(errorPrefix_A) || error.message.includes(errorPrefix_B)) {
+    error.reason = error.message.replace(errorPrefix_A, '')
+    error.reason = error.message.replace(errorPrefix_B, '')
     // Truffle 5 sometimes add an extra ' -- Reason given: reason.' to the error message 🤷
     error.reason = error.reason.replace(` -- Reason given: ${reason}.`, '').trim()
   }

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -15,7 +15,10 @@ const config = {
         },
       },
     },
-  }
+  },
+  plugins: [
+    "solidity-coverage"
+  ]
 }
 
 module.exports = config


### PR DESCRIPTION
Fixes #86 

@facuspagnuolo Sorry this took a while...

This upgrades to a new solidity-coverage beta which contains breaking changes. It runs on an in-process ganache-core supplied by truffle and launches as a truffle plugin. Instrumentation data is collected in-memory so it should be a bit faster. 

All of the nonsense about `copyPackages`, weird problems with libraries and double-compilation is finished though. Installation is much simpler. Am leaving notes in the diff explaining each change.

Have added myself to the watch list here and please ping if you see anything weird. The beta PR remains open and under active development [here](https://github.com/sc-forks/solidity-coverage/pull/372).

~~[EDIT -- WIP because the `--file <glob>` command option to select a subset of the tests is not grabbing all the files correctly]~~ (Fixed)

[Edit 2 -- 
Unfortunately it looks like there will continue to be things that don't work perfectly  :/

+ **gas measurement tests**: coverage still distorts gas a little and many of the `hex-sum-tree-gas` tests fail. 
+ **very long running individual tests**: In the `registry` there are single tests that take +/- 3 min to complete normally & it looks like coverage is slowing things down another +100%. Those tests timeout, not sure how long they take to complete. 

It might be possible to skip coverage for these without affecting the measurement of logic correctness as such because they're simulations? Idk. 

@facuspagnuolo  Please feel free to close this PR - it's just a draft to explain how the new coverage installs and get a sense of what works (and doesn't). 
]
