### PR TITLE
Court: Add tests for juror fees

### DIFF
--- a/contracts/court/Court.sol
+++ b/contracts/court/Court.sol
@@ -772,6 +772,7 @@ contract Court is IJurorsRegistryOwner, ICRVotingOwner, ISubscriptionsOwner, Tim
             uint64 jurorsNumber,
             uint64 selectedJurors,
             address triggeredBy,
+            uint256 jurorFees,
             bool settledPenalties,
             uint256 collectedTokens,
             uint64 coherentJurors,
@@ -779,14 +780,15 @@ contract Court is IJurorsRegistryOwner, ICRVotingOwner, ISubscriptionsOwner, Tim
         )
     {
         Dispute storage dispute = disputes[_disputeId];
-        AdjudicationRound storage round = dispute.rounds[_roundId];
-
         state = _adjudicationStateAt(dispute, _roundId, _getCurrentTermId());
+
+        AdjudicationRound storage round = dispute.rounds[_roundId];
         draftTerm = round.draftTermId;
         delayedTerms = round.delayedTerms;
         jurorsNumber = round.jurorsNumber;
         selectedJurors = round.selectedJurors;
         triggeredBy = round.triggeredBy;
+        jurorFees = round.jurorFees;
         settledPenalties = round.settledPenalties;
         coherentJurors = round.coherentJurors;
         collectedTokens = round.collectedTokens;
@@ -1253,7 +1255,6 @@ contract Court is IJurorsRegistryOwner, ICRVotingOwner, ISubscriptionsOwner, Tim
 
         // Otherwise, return the times the active balance of the juror fits in the min active balance, multiplying
         // it by a round factor to ensure a better precision rounding.
-        // TODO: review, we are not using the final round discount here
         return (FINAL_ROUND_WEIGHT_PRECISION.mul(activeBalance) / minJurorsActiveBalance).toUint64();
     }
 

--- a/test/court/court-appeal.js
+++ b/test/court/court-appeal.js
@@ -159,11 +159,12 @@ contract('Court', ([_, disputer, drafter, appealMaker, appealTaker, juror500, ju
                   it('does not modify the current round of the dispute', async () => {
                     await court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker })
 
-                    const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, triggeredBy, settledPenalties, collectedTokens } = await courtHelper.getRound(disputeId, roundId)
+                    const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, triggeredBy, jurorFees, settledPenalties, collectedTokens } = await courtHelper.getRound(disputeId, roundId)
                     assert.equal(draftTerm.toString(), draftTermId, 'current round draft term does not match')
                     assert.equal(delayedTerms.toString(), 0, 'current round delay term does not match')
                     assert.equal(roundJurorsNumber.toString(), jurorsNumber, 'current round jurors number does not match')
                     assert.equal(selectedJurors.toString(), jurorsNumber, 'current round selected jurors number does not match')
+                    assert.equal(jurorFees.toString(), courtHelper.jurorFee.mul(bn(jurorsNumber)).toString(), 'current round juror fees do not match')
                     assert.equal(triggeredBy, disputer, 'current round trigger does not match')
                     assert.equal(settledPenalties, false, 'current round penalties should not be settled')
                     assert.equal(collectedTokens.toString(), 0, 'current round collected tokens should be zero')

--- a/test/court/court-confirm-appeal.js
+++ b/test/court/court-confirm-appeal.js
@@ -184,7 +184,7 @@ contract('Court', ([_, disputer, drafter, appealMaker, appealTaker, juror500, ju
                       it('creates a new round for the given dispute', async () => {
                         await court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker })
 
-                        const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, triggeredBy, settledPenalties, collectedTokens } = await courtHelper.getRound(disputeId, roundId + 1)
+                        const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, triggeredBy, settledPenalties, jurorFees, collectedTokens } = await courtHelper.getRound(disputeId, roundId + 1)
 
                         const nextRoundStartTerm = await courtHelper.getNextRoundStartTerm(disputeId, roundId)
                         assert.equal(draftTerm.toString(), nextRoundStartTerm.toString(), 'new round draft term does not match')
@@ -192,6 +192,10 @@ contract('Court', ([_, disputer, drafter, appealMaker, appealTaker, juror500, ju
 
                         const nextRoundJurorsNumber = await courtHelper.getNextRoundJurorsNumber(disputeId, roundId)
                         assert.equal(roundJurorsNumber.toString(), nextRoundJurorsNumber.toString(), 'new round jurors number does not match')
+
+                        const nextRoundJurorFees = await courtHelper.getNextRoundJurorFees(disputeId, roundId)
+                        assert.equal(jurorFees.toString(), nextRoundJurorFees.toString(), 'new round juror fees do not match')
+
                         assert.equal(selectedJurors.toString(), 0, 'new round selected jurors number does not match')
                         assert.equal(triggeredBy, appealTaker, 'new round trigger does not match')
                         assert.equal(settledPenalties, false, 'new round penalties should not be settled')
@@ -199,15 +203,16 @@ contract('Court', ([_, disputer, drafter, appealMaker, appealTaker, juror500, ju
                       })
 
                       it('does not modify the current round of the dispute', async () => {
-                        const { draftTerm: previousDraftTerm, delayedTerms: previousDelayedTerms, roundJurorsNumber: previousJurorsNumber, triggeredBy: previousTriggeredBy } = await courtHelper.getRound(disputeId, roundId)
+                        const { draftTerm: previousDraftTerm, delayedTerms: previousDelayedTerms, roundJurorsNumber: previousJurorsNumber, jurorFees: previousJurorFees, triggeredBy: previousTriggeredBy } = await courtHelper.getRound(disputeId, roundId)
 
                         await court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker })
 
-                        const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, triggeredBy, settledPenalties, collectedTokens } = await courtHelper.getRound(disputeId, roundId)
+                        const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, jurorFees, triggeredBy, settledPenalties, collectedTokens } = await courtHelper.getRound(disputeId, roundId)
                         assert.equal(draftTerm.toString(), previousDraftTerm.toString(), 'current round draft term does not match')
                         assert.equal(delayedTerms.toString(), previousDelayedTerms.toString(), 'current round delay term does not match')
                         assert.equal(roundJurorsNumber.toString(), previousJurorsNumber.toString(), 'current round jurors number does not match')
                         assert.equal(selectedJurors.toString(), previousJurorsNumber.toString(), 'current round selected jurors number does not match')
+                        assert.equal(jurorFees.toString(), previousJurorFees.toString(), 'current round juror fees do not match')
                         assert.equal(triggeredBy, previousTriggeredBy, 'current round trigger does not match')
                         assert.equal(settledPenalties, false, 'current round penalties should not be settled')
                         assert.equal(collectedTokens.toString(), 0, 'current round collected tokens should be zero')

--- a/test/court/court-disputes.js
+++ b/test/court/court-disputes.js
@@ -59,12 +59,13 @@ contract('Court', ([_, sender]) => {
           it('creates a new adjudication round', async () => {
             await court.createDispute(arbitrable.address, possibleRulings, jurorsNumber, draftTermId, { from: sender })
 
-            const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, triggeredBy, settledPenalties, collectedTokens } = await courtHelper.getRound(0, 0)
+            const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, jurorFees, triggeredBy, settledPenalties, collectedTokens } = await courtHelper.getRound(0, 0)
 
             assert.equal(draftTerm.toString(), draftTermId, 'round draft term does not match')
             assert.equal(delayedTerms.toString(), 0, 'round delay term does not match')
             assert.equal(roundJurorsNumber.toString(), jurorsNumber, 'round jurors number does not match')
             assert.equal(selectedJurors.toString(), 0, 'round selected jurors number does not match')
+            assert.equal(jurorFees.toString(), courtHelper.jurorFee.mul(bn(jurorsNumber)).toString(), 'round juror fees do not match')
             assert.equal(triggeredBy, sender, 'round trigger does not match')
             assert.equal(settledPenalties, false, 'round penalties should not be settled')
             assert.equal(collectedTokens.toString(), 0, 'round collected tokens should be zero')
@@ -229,12 +230,13 @@ contract('Court', ([_, sender]) => {
 
       context('when the round exists', async () => {
         it('returns the requested round', async () => {
-          const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, triggeredBy, settledPenalties, collectedTokens } = await courtHelper.getRound(0, 0)
+          const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, jurorFees, triggeredBy, settledPenalties, collectedTokens } = await courtHelper.getRound(0, 0)
 
           assert.equal(draftTerm.toString(), draftTermId, 'round draft term does not match')
           assert.equal(delayedTerms.toString(), 0, 'round delay term does not match')
           assert.equal(roundJurorsNumber.toString(), jurorsNumber, 'round jurors number does not match')
           assert.equal(selectedJurors.toString(), 0, 'round selected jurors number does not match')
+          assert.equal(jurorFees.toString(), courtHelper.jurorFee.mul(bn(jurorsNumber)).toString(), 'round juror fees do not match')
           assert.equal(triggeredBy, sender, 'round trigger does not match')
           assert.equal(settledPenalties, false, 'round penalties should not be settled')
           assert.equal(collectedTokens.toString(), 0, 'round collected tokens should be zero')

--- a/test/court/court-settle.js
+++ b/test/court/court-settle.js
@@ -271,7 +271,7 @@ contract('Court', ([_, disputer, drafter, appealMaker, appealTaker, juror500, ju
                   }
                 })
 
-                it('reimburses winning juror fees', async () => {
+                it('rewards winning jurors with fees', async () => {
                   const { accounting, feeToken } = courtHelper
                   const { jurorFees } = await courtHelper.getRound(disputeId, roundId)
 

--- a/test/court/court-settle.js
+++ b/test/court/court-settle.js
@@ -265,9 +265,24 @@ contract('Court', ([_, disputer, drafter, appealMaker, appealTaker, juror500, ju
 
                     const { available } = await courtHelper.jurorsRegistry.balanceOf(address)
                     const expectedReward = expectedCollectedTokens.mul(bn(weight)).div(bn(expectedCoherentJurors))
-                    const expectedCurrentAvailableBalance = previousBalances[address].available.add(expectedReward);
+                    const expectedCurrentAvailableBalance = previousBalances[address].available.add(expectedReward)
 
                     assert.equal(expectedCurrentAvailableBalance.toString(), available.toString(), 'current available balance does not match')
+                  }
+                })
+
+                it('reimburses winning juror fees', async () => {
+                  const { accounting, feeToken } = courtHelper
+                  const { jurorFees } = await courtHelper.getRound(disputeId, roundId)
+
+                  for(const { address, weight } of expectedWinningJurors) {
+                    const previousJurorBalance = await accounting.balanceOf(feeToken.address, address)
+
+                    await court.settleReward(disputeId, roundId, address)
+
+                    const expectedReward = jurorFees.mul(bn(weight)).div(bn(expectedCoherentJurors))
+                    const currentJurorBalance = await accounting.balanceOf(feeToken.address, address)
+                    assert.equal(currentJurorBalance.toString(), previousJurorBalance.add(expectedReward), 'juror fee balance does not match')
                   }
                 })
 

--- a/test/helpers/court.js
+++ b/test/helpers/court.js
@@ -66,8 +66,8 @@ module.exports = (web3, artifacts) => {
     }
 
     async getRound(disputeId, roundId) {
-      const { draftTerm, delayedTerms, jurorsNumber: roundJurorsNumber, selectedJurors, triggeredBy, settledPenalties, collectedTokens, coherentJurors, state: roundState } = await this.court.getRound(disputeId, roundId)
-      return { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, triggeredBy, settledPenalties, collectedTokens, coherentJurors, roundState }
+      const { draftTerm, delayedTerms, jurorsNumber: roundJurorsNumber, selectedJurors, triggeredBy, settledPenalties, jurorFees, collectedTokens, coherentJurors, state: roundState } = await this.court.getRound(disputeId, roundId)
+      return { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, triggeredBy, settledPenalties, jurorFees, collectedTokens, coherentJurors, roundState }
     }
 
     async getAppeal(disputeId, roundId) {


### PR DESCRIPTION
This PR includes:
- Added rounds' `jurorsFee` to the list of returned values when fetching a round from the Court. 
- Added `jurorsFee` checks to all the rounds-related checks in tests
- Test juror fees when settling rewards