### PR TITLE
Court: Include leaked votes in settle tests

### DIFF
--- a/test/court/court-settle.js
+++ b/test/court/court-settle.js
@@ -44,7 +44,7 @@ contract('Court', ([_, disputer, drafter, appealMaker, appealTaker, juror500, ju
       context('when the given round is valid', () => {
         const roundId = 0
         const voters = [
-          { address: juror1000, weight: 1, outcome: OUTCOMES.LOW },
+          { address: juror1000, weight: 1, outcome: OUTCOMES.LEAKED },
           { address: juror2000, weight: 1, outcome: OUTCOMES.HIGH },
           { address: juror4000, weight: 1, outcome: OUTCOMES.LOW },
         ]

--- a/test/helpers/court.js
+++ b/test/helpers/court.js
@@ -3,7 +3,7 @@ const { bn, bigExp } = require('./numbers')
 const { decodeEventsOfType } = require('./decodeEvent')
 const { NEXT_WEEK, ONE_DAY } = require('./time')
 const { getEvents, getEventArgument } = require('@aragon/os/test/helpers/events')
-const { SALT, getVoteId, encryptVote, oppositeOutcome, outcomeFor } = require('../helpers/crvoting')
+const { SALT, OUTCOMES, getVoteId, encryptVote, oppositeOutcome, outcomeFor } = require('../helpers/crvoting')
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
@@ -242,6 +242,9 @@ module.exports = (web3, artifacts) => {
         // if no outcome was set for the given outcome, pick one based on its index
         if (!outcome) outcome = outcomeFor(i)
         await this.voting.commit(voteId, encryptVote(outcome), { from: address })
+        if (outcome == OUTCOMES.LEAKED) {
+          await this.voting.leak(voteId, address, outcome, SALT)
+        }
       }
 
       // move to reveal period
@@ -255,7 +258,9 @@ module.exports = (web3, artifacts) => {
         let { address, outcome } = voters[i]
         // if no outcome was set for the given outcome, pick one based on its index
         if (!outcome) outcome = outcomeFor(i)
-        await this.voting.reveal(voteId, outcome, SALT, { from: address })
+        if (outcome != OUTCOMES.LEAKED) {
+          await this.voting.reveal(voteId, outcome, SALT, { from: address })
+        }
       }
 
       // move to appeal period


### PR DESCRIPTION
Fixes #88.
Jurors with leaked votes were already being slashed, same way as
voters in the losing side. We consider this enough for now.
We also think there is no need to incentivize calling leak function
because there problably is enough incentive and because it would add
accounting complexity.