### PR TITLE
Subscriptions: Implement pause/resume functionality

### DIFF
--- a/contracts/court/Court.sol
+++ b/contracts/court/Court.sol
@@ -279,6 +279,7 @@ contract Court is IJurorsRegistryOwner, ICRVotingOwner, ISubscriptionsOwner, Tim
     *        _periodDuration Length of Subscription periods
     *        _feeAmount Amount of periodic fees
     *        _prePaymentPeriods Max number of payments that can be done in advance
+    *        _resumePrePaidPeriods Number of periods to be paid in advance when resuming a subscription activity
     *        _latePaymentPenaltyPct Penalty for not paying on time
     *        _governorSharePct Share of paid fees that goes to governor
     */
@@ -297,7 +298,7 @@ contract Court is IJurorsRegistryOwner, ICRVotingOwner, ISubscriptionsOwner, Tim
         uint16[2] memory _pcts, //_penaltyPct, _finalRoundReduction
         uint64 _appealStepFactor,
         uint32 _maxRegularAppealRounds,
-        uint256[5] memory _subscriptionParams // _periodDuration, _feeAmount, _prePaymentPeriods, _latePaymentPenaltyPct, _governorSharePct
+        uint256[6] memory _subscriptionParams // _periodDuration, _feeAmount, _prePaymentPeriods, _resumePrePaidPeriods, _latePaymentPenaltyPct, _governorSharePct
     ) public {
         require(_firstTermStartTime >= getTimestamp64() + _termDuration, ERROR_BAD_FIRST_TERM_START_TIME);
 
@@ -1627,7 +1628,7 @@ contract Court is IJurorsRegistryOwner, ICRVotingOwner, ISubscriptionsOwner, Tim
     }
 
     // TODO: move to a factory contract
-    function _initSubscriptions(ERC20 _feeToken, uint256[5] memory _subscriptionParams) private {
+    function _initSubscriptions(ERC20 _feeToken, uint256[6] memory _subscriptionParams) private {
         uint64 maxUint64 = uint64(-1);
         uint256 maxUint16 = uint16(-1);
 
@@ -1641,8 +1642,9 @@ contract Court is IJurorsRegistryOwner, ICRVotingOwner, ISubscriptionsOwner, Tim
             _feeToken,
             _subscriptionParams[1],         // _feeAmount
             _subscriptionParams[2],         // _prePaymentPeriods
-            uint16(_subscriptionParams[3]), // _latePaymentPenaltyPct
-            uint16(_subscriptionParams[4])  // _governorSharePct
+            _subscriptionParams[3],         // _resumePrePaidPeriods
+            uint16(_subscriptionParams[4]), // _latePaymentPenaltyPct
+            uint16(_subscriptionParams[5])  // _governorSharePct
         );
     }
 }

--- a/contracts/subscriptions/ISubscriptions.sol
+++ b/contracts/subscriptions/ISubscriptions.sol
@@ -14,6 +14,7 @@ interface ISubscriptions {
         ERC20 _feeToken,
         uint256 _feeAmount,
         uint256 _prePaymentPeriods,
+        uint256 _resumePrePaidPeriods,
         uint16 _latePaymentPenaltyPct,
         uint16 _governorSharePct
     ) external;
@@ -22,5 +23,6 @@ interface ISubscriptions {
     function setPrePaymentPeriods(uint256 _prePaymentPeriods) external;
     function setLatePaymentPenaltyPct(uint16 _latePaymentPenaltyPct) external;
     function setGovernorSharePct(uint16 _governorSharePct) external;
+    function setResumePrePaidPeriods(uint256 _resumePrePaidPeriods) external;
     function isUpToDate(address _subscriber) external view returns (bool);
 }

--- a/contracts/test/court/CourtMock.sol
+++ b/contracts/test/court/CourtMock.sol
@@ -20,7 +20,7 @@ contract CourtMock is Court, TimeHelpersMock {
         uint16[2] memory _pcts,
         uint64 _appealStepFactor,
         uint32 _maxRegularAppealRounds,
-        uint256[5] memory _subscriptionParams // _periodDuration, _feeAmount, _prePaymentPeriods, _latePaymentPenaltyPct, _governorSharePct
+        uint256[6] memory _subscriptionParams // _periodDuration, _feeAmount, _prePaymentPeriods, _resumePrePaidPeriods, _latePaymentPenaltyPct, _governorSharePct
     )
         Court(
             _termDuration,

--- a/contracts/test/subscriptions/SubscriptionsMock.sol
+++ b/contracts/test/subscriptions/SubscriptionsMock.sol
@@ -10,12 +10,13 @@ import "../../subscriptions/ISubscriptionsOwner.sol";
 contract SubscriptionsMock is ISubscriptions {
     bool upToDate;
 
-    function init(ISubscriptionsOwner, IJurorsRegistry, uint64, ERC20, uint256, uint256, uint16, uint16) external {}
+    function init(ISubscriptionsOwner, IJurorsRegistry, uint64, ERC20, uint256, uint256, uint256, uint16, uint16) external {}
     function setFeeAmount(uint256) external {}
     function setFeeToken(ERC20, uint256) external {}
     function setPrePaymentPeriods(uint256) external {}
     function setLatePaymentPenaltyPct(uint16) external {}
     function setGovernorSharePct(uint16) external {}
+    function setResumePrePaidPeriods(uint256) external {}
 
     function setUpToDate(bool _upToDate) external {
         upToDate = _upToDate;

--- a/contracts/test/subscriptions/SubscriptionsOwnerMock.sol
+++ b/contracts/test/subscriptions/SubscriptionsOwnerMock.sol
@@ -37,6 +37,10 @@ contract SubscriptionsOwnerMock is ISubscriptionsOwner, IJurorsRegistryOwner {
         subscription.setGovernorSharePct(_governorSharePct);
     }
 
+    function setResumePrePaidPeriods(uint256 _resumePrePaidPeriods) external {
+        subscription.setResumePrePaidPeriods(_resumePrePaidPeriods);
+    }
+
     function mockSetTerm(uint64 _termId) external {
         termId = _termId;
     }

--- a/test/helpers/court.js
+++ b/test/helpers/court.js
@@ -46,12 +46,14 @@ module.exports = (web3, artifacts) => {
     appealStepFactor:                   bn(3),           //  each time a new appeal occurs, the amount of jurors to be drafted will be incremented 3 times
     maxRegularAppealRounds:             bn(2),           //  there can be up to 2 appeals in total per dispute
     jurorsMinActiveBalance:             bigExp(100, 18), //  100 ANJ is the minimum balance jurors must activate to participate in the Court
-    subscriptionPeriodDuration:         bn(0),           //  none subscription period
-    subscriptionFeeAmount:              bn(0),           //  none subscription fee
-    subscriptionPrePaymentPeriods:      bn(0),           //  none subscription pre payment period
+    finalRoundWeightPrecision:          bn(1000),        //  use to improve division rounding for final round maths
+
+    subscriptionPeriodDuration:         bn(10),          //  each subscription period lasts 10 terms
+    subscriptionFeeAmount:              bigExp(100, 18), //  100 fee tokens per subscription period
+    subscriptionPrePaymentPeriods:      bn(15),          //  15 subscription pre payment period
+    subscriptionResumePrePaidPeriods:   bn(10),          //  10 pre-paid periods when resuming activity
     subscriptionLatePaymentPenaltyPct:  bn(0),           //  none subscription late payment penalties
     subscriptionGovernorSharePct:       bn(0),           //  none subscription governor shares
-    finalRoundWeightPrecision:          bn(1000),        //  use to improve division rounding for final round maths
   }
 
   class CourtHelper {
@@ -357,7 +359,7 @@ module.exports = (web3, artifacts) => {
         [ this.penaltyPct, this.finalRoundReduction ],
         this.appealStepFactor,
         this.maxRegularAppealRounds,
-        [ this.subscriptionPeriodDuration, this.subscriptionFeeAmount, this.subscriptionPrePaymentPeriods, this.subscriptionLatePaymentPenaltyPct, this.subscriptionGovernorSharePct ]
+        [ this.subscriptionPeriodDuration, this.subscriptionFeeAmount, this.subscriptionPrePaymentPeriods, this.subscriptionResumePrePaidPeriods, this.subscriptionLatePaymentPenaltyPct, this.subscriptionGovernorSharePct ]
       )
 
       const zeroTermStartTime = this.firstTermStartTime.sub(this.termDuration)

--- a/test/subscriptions/subscriptions-initialization.js
+++ b/test/subscriptions/subscriptions-initialization.js
@@ -13,6 +13,7 @@ contract('CourtSubscriptions', ([_, something]) => {
 
   const FEE_AMOUNT = bigExp(10, 18)
   const PREPAYMENT_PERIODS = 12
+  const RESUME_PRE_PAID_PERIODS = 10
   const PERIOD_DURATION = 24 * 30           // 30 days, assuming terms are 1h
   const GOVERNOR_SHARE_PCT = bn(100)        // 100‱ = 1%
   const LATE_PAYMENT_PENALTY_PCT = bn(1000) // 1000‱ = 10%
@@ -28,13 +29,13 @@ contract('CourtSubscriptions', ([_, something]) => {
     context('when the subscriptions is not initialized', () => {
       context('when the initialization succeeds', () => {
         it('is initialized', async () => {
-          await subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT)
+          await subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT)
 
           assert.isTrue(await subscriptions.hasInitialized(), 'subscriptions is not initialized')
         })
 
         it('sets initial config correctly', async () => {
-          await subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT)
+          await subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT)
 
           assert.equal(await subscriptions.getOwner(), subscriptionsOwner.address, 'subscriptions owner does not match')
           assert.equal(await subscriptions.currentFeeToken(), feeToken.address, 'fee token does not match')
@@ -55,7 +56,7 @@ contract('CourtSubscriptions', ([_, something]) => {
           const owner = ZERO_ADDRESS
 
           it('reverts', async () => {
-            await assertRevert(subscriptions.init(owner, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_FEE_TOKEN_NOT_CONTRACT')
+            await assertRevert(subscriptions.init(owner, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_FEE_TOKEN_NOT_CONTRACT')
           })
         })
 
@@ -64,7 +65,7 @@ contract('CourtSubscriptions', ([_, something]) => {
           const owner = something
 
           it('reverts', async () => {
-            await assertRevert(subscriptions.init(owner, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_FEE_TOKEN_NOT_CONTRACT')
+            await assertRevert(subscriptions.init(owner, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_FEE_TOKEN_NOT_CONTRACT')
           })
         })
 
@@ -72,7 +73,7 @@ contract('CourtSubscriptions', ([_, something]) => {
           const jurorsRegistryAddress = ZERO_ADDRESS
 
           it('reverts', async () => {
-            await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistryAddress, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_REGISTRY_NOT_CONTRACT')
+            await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistryAddress, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_REGISTRY_NOT_CONTRACT')
           })
         })
 
@@ -80,7 +81,7 @@ contract('CourtSubscriptions', ([_, something]) => {
           const jurorsRegistryAddress = something
 
           it('reverts', async () => {
-            await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistryAddress, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_REGISTRY_NOT_CONTRACT')
+            await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistryAddress, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_REGISTRY_NOT_CONTRACT')
           })
         })
 
@@ -88,7 +89,7 @@ contract('CourtSubscriptions', ([_, something]) => {
           const periodDuration = 0
 
           it('reverts', async () => {
-            await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, periodDuration, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_PERIOD_DURATION_ZERO')
+            await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, periodDuration, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_PERIOD_DURATION_ZERO')
           })
         })
 
@@ -96,7 +97,7 @@ contract('CourtSubscriptions', ([_, something]) => {
           const feeTokenAddress = ZERO_ADDRESS
 
           it('reverts', async () => {
-            await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeTokenAddress, FEE_AMOUNT, PREPAYMENT_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_FEE_TOKEN_NOT_CONTRACT')
+            await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeTokenAddress, FEE_AMOUNT, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_FEE_TOKEN_NOT_CONTRACT')
           })
         })
 
@@ -104,7 +105,7 @@ contract('CourtSubscriptions', ([_, something]) => {
           const feeTokenAddress = something
 
           it('reverts', async () => {
-            await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeTokenAddress, FEE_AMOUNT, PREPAYMENT_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_FEE_TOKEN_NOT_CONTRACT')
+            await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeTokenAddress, FEE_AMOUNT, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_FEE_TOKEN_NOT_CONTRACT')
           })
         })
 
@@ -112,7 +113,7 @@ contract('CourtSubscriptions', ([_, something]) => {
           const feeAmount = 0
 
           it('reverts', async () => {
-            await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, feeAmount, PREPAYMENT_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_FEE_AMOUNT_ZERO')
+            await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, feeAmount, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_FEE_AMOUNT_ZERO')
           })
         })
 
@@ -120,7 +121,7 @@ contract('CourtSubscriptions', ([_, something]) => {
           const prePaymentPeriods = 0
 
           it('reverts', async () => {
-            await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, prePaymentPeriods, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_PREPAYMENT_PERIODS_ZERO')
+            await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, prePaymentPeriods, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_PREPAYMENT_PERIODS_ZERO')
           })
         })
 
@@ -128,7 +129,15 @@ contract('CourtSubscriptions', ([_, something]) => {
           const governorSharePct = bn(10001)
 
           it('reverts', async () => {
-            await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, LATE_PAYMENT_PENALTY_PCT, governorSharePct), 'CS_OVERRATED_GOVERNOR_SHARE_PCT')
+            await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, governorSharePct), 'CS_OVERRATED_GOVERNOR_SHARE_PCT')
+          })
+        })
+
+        context('when the given resume pre-paid periods is above the pre-payment periods', () => {
+          const resumePrePaidPeriods = PREPAYMENT_PERIODS + 1
+
+          it('reverts', async () => {
+            await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, resumePrePaidPeriods, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'CS_RESUME_PRE_PAID_PERIODS_BIG')
           })
         })
       })
@@ -136,11 +145,11 @@ contract('CourtSubscriptions', ([_, something]) => {
 
     context('when the subscriptions was already initialized', () => {
       beforeEach('initialize subscriptions', async () => {
-        await subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT)
+        await subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT)
       })
 
       it('reverts', async () => {
-        await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'INIT_ALREADY_INITIALIZED')
+        await assertRevert(subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT), 'INIT_ALREADY_INITIALIZED')
       })
     })
   })

--- a/test/subscriptions/subscriptions-jurors.js
+++ b/test/subscriptions/subscriptions-jurors.js
@@ -16,6 +16,7 @@ contract('CourtSubscriptions', ([_, payer, subscriberPeriod0, subscriberPeriod1,
   const PCT_BASE = bn(10000)
   const FEE_AMOUNT = bigExp(10, 18)
   const PREPAYMENT_PERIODS = 12
+  const RESUME_PRE_PAID_PERIODS = 10
   const PERIOD_DURATION = 24 * 30           // 30 days, assuming terms are 1h
   const GOVERNOR_SHARE_PCT = bn(100)        // 100‱ = 1%
   const LATE_PAYMENT_PENALTY_PCT = bn(1000) // 1000‱ = 10%
@@ -33,7 +34,7 @@ contract('CourtSubscriptions', ([_, payer, subscriberPeriod0, subscriberPeriod1,
     context('when the subscriptions was already initialized', () => {
       beforeEach('initialize subscriptions', async () => {
         await jurorsRegistry.init(subscriptionsOwner.address, jurorToken.address, MIN_JURORS_ACTIVE_TOKENS)
-        await subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT)
+        await subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT)
       })
 
       context('when there were some jurors active', () => {

--- a/test/subscriptions/subscriptions-pause-resume.js
+++ b/test/subscriptions/subscriptions-pause-resume.js
@@ -1,0 +1,414 @@
+const { bn, bigExp } = require('../helpers/numbers')
+const { assertRevert } = require('../helpers/assertThrow')
+const { assertAmountOfEvents, assertEvent } = require('../helpers/assertEvent')
+
+const CourtSubscriptions = artifacts.require('CourtSubscriptions')
+const SubscriptionsOwner = artifacts.require('SubscriptionsOwnerMock')
+const JurorsRegistry = artifacts.require('JurorsRegistry')
+const ERC20 = artifacts.require('ERC20Mock')
+
+contract('CourtSubscriptions', ([_, payer, subscriber]) => {
+  let subscriptions, subscriptionsOwner, jurorsRegistry, feeToken
+
+  const PCT_BASE = bn(10000)
+  const FEE_AMOUNT = bigExp(10, 18)
+  const PREPAYMENT_PERIODS = 15
+  const RESUME_PRE_PAID_PERIODS = 10
+  const PERIOD_DURATION = 24 * 30           // 30 days, assuming terms are 1h
+  const GOVERNOR_SHARE_PCT = bn(100)        // 100‱ = 1%
+  const LATE_PAYMENT_PENALTY_PCT = bn(1000) // 1000‱ = 10%
+
+  const penaltyFees = (n, pct) => n.mul(pct.add(PCT_BASE)).div(PCT_BASE)
+
+  beforeEach('create base contracts', async () => {
+    subscriptions = await CourtSubscriptions.new()
+    subscriptionsOwner = await SubscriptionsOwner.new(subscriptions.address)
+    jurorsRegistry = await JurorsRegistry.new()
+    feeToken = await ERC20.new('Subscriptions Fee Token', 'SFT', 18)
+  })
+
+  describe('pause/resume', () => {
+    beforeEach('initialize subscriptions', async () => {
+      await subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT)
+      await subscriptionsOwner.mockSetTerm(PERIOD_DURATION)
+    })
+
+    beforeEach('mint fee tokens and subscribe', async () => {
+      const balance = FEE_AMOUNT.mul(bn(10000))
+      await feeToken.generateTokens(payer, balance)
+      await feeToken.approve(subscriptions.address, balance, { from: payer })
+      await subscriptions.payFees(subscriber, 1, { from: payer })
+    })
+
+    const itIsUpToDate = (resumePaidPeriods) => {
+      it('is up-to-date', async () => {
+        await subscriptions.payFees(subscriber, resumePaidPeriods, { from: payer })
+
+        assert.isTrue(await subscriptions.isUpToDate(subscriber), 'subscriber should be up-to-date')
+      })
+
+      it('is not paused', async () => {
+        await subscriptions.payFees(subscriber, resumePaidPeriods, { from: payer })
+        const { subscribed, paused, previousDelayedPeriods } = await subscriptions.getSubscriber(subscriber)
+
+        assert.isTrue(subscribed, 'subscriber should be subscribed')
+        assert.isFalse(paused, 'subscriber should not be paused')
+        assert.equal(previousDelayedPeriods.toString(), 0, 'previous delayed periods does not match')
+      })
+    }
+
+    const itComputesLastAndDelayedPeriodsCorrectly = (resumePaidPeriods, expectedMovedPeriods, expectedDelayedPeriods) => {
+      it('computes last period id correctly', async () => {
+        const currentPeriodId = (await subscriptions.getCurrentPeriodId()).toNumber()
+        const expectedLastPeriodId = currentPeriodId + expectedMovedPeriods
+
+        const { newLastPeriodId } = await subscriptions.getPayFeesDetails(subscriber, resumePaidPeriods)
+        assert.equal(newLastPeriodId.toString(), expectedLastPeriodId, 'new last period id does not match')
+
+        await subscriptions.payFees(subscriber, resumePaidPeriods, { from: payer })
+        const { lastPaymentPeriodId } = await subscriptions.getSubscriber(subscriber)
+        assert.equal(lastPaymentPeriodId.toString(), expectedLastPeriodId, 'new last period id does not match')
+      })
+
+      it('computes number of delayed periods correctly', async () => {
+        const previousDelayedPeriods = await subscriptions.getDelayedPeriods(subscriber)
+
+        await subscriptions.payFees(subscriber, resumePaidPeriods, { from: payer })
+
+        const currentDelayedPeriods = await subscriptions.getDelayedPeriods(subscriber)
+        assert.equal(currentDelayedPeriods.toString(), previousDelayedPeriods.sub(bn(expectedDelayedPeriods)).toString(), 'number of delayed periods does not match')
+      })
+    }
+
+    const itPaysNormalFees = (resumePaidPeriods, expectedRegularPeriods, expectedDelayedPeriods) => {
+      const expectedRegularFees = FEE_AMOUNT.mul(bn(expectedRegularPeriods))
+      const expectedDelayedFees = penaltyFees(FEE_AMOUNT.mul(bn(expectedDelayedPeriods)), LATE_PAYMENT_PENALTY_PCT)
+      const expectedTotalPaidFees = expectedRegularFees.add(expectedDelayedFees)
+      const expectedGovernorFees = GOVERNOR_SHARE_PCT.mul(expectedTotalPaidFees).div(PCT_BASE)
+
+      it('pays the requested periods subscriptions', async () => {
+        const previousPayerBalance = await feeToken.balanceOf(payer)
+        const previousSubscriptionsBalance = await feeToken.balanceOf(subscriptions.address)
+
+        const { amountToPay } = await subscriptions.getPayFeesDetails(subscriber, resumePaidPeriods)
+        assert.equal(amountToPay.toString(), expectedTotalPaidFees.toString(), 'amount to be paid does not match')
+
+        await subscriptions.payFees(subscriber, resumePaidPeriods, { from: payer })
+
+        const currentSubscriptionsBalance = await feeToken.balanceOf(subscriptions.address)
+        assert.equal(currentSubscriptionsBalance.toString(), previousSubscriptionsBalance.add(expectedTotalPaidFees).toString(), 'subscriptions balances do not match')
+
+        const currentPayerBalance = await feeToken.balanceOf(payer)
+        assert.equal(currentPayerBalance.toString(), previousPayerBalance.sub(expectedTotalPaidFees).toString(), 'payer balances do not match')
+      })
+
+      it('pays the governor fees', async () => {
+        const { newLastPeriodId } = await subscriptions.getPayFeesDetails(subscriber, resumePaidPeriods)
+        const previousGovernorFees = await subscriptions.accumulatedGovernorFees()
+
+        const receipt = await subscriptions.payFees(subscriber, resumePaidPeriods, { from: payer })
+
+        const currentGovernorFees = await subscriptions.accumulatedGovernorFees()
+        assert.equal(currentGovernorFees.toString(), previousGovernorFees.add(expectedGovernorFees).toString(), 'governor fees do not match')
+
+        const expectedCollectedFees = expectedTotalPaidFees.sub(expectedGovernorFees)
+        assertAmountOfEvents(receipt, 'FeesPaid')
+        assertEvent(receipt, 'FeesPaid', { subscriber, periods: resumePaidPeriods, newLastPeriodId, collectedFees: expectedCollectedFees, governorFee: expectedGovernorFees })
+      })
+    }
+
+    const itPaysResumingFees = (resumePaidPeriods, expectedRegularPeriods, expectedDelayedPeriods) => {
+      const expectedRegularFees = FEE_AMOUNT.mul(bn(expectedRegularPeriods))
+      const expectedResumeFees = FEE_AMOUNT.mul(bn(RESUME_PRE_PAID_PERIODS))
+      const expectedDelayedFees = penaltyFees(FEE_AMOUNT.mul(bn(expectedDelayedPeriods)), LATE_PAYMENT_PENALTY_PCT)
+      const expectedTotalPaidFees = expectedRegularFees.add(expectedDelayedFees).add(expectedResumeFees)
+      const expectedGovernorFees = GOVERNOR_SHARE_PCT.mul(expectedTotalPaidFees).div(PCT_BASE)
+
+      it('pays the requested periods subscriptions', async () => {
+        const previousPayerBalance = await feeToken.balanceOf(payer)
+        const previousSubscriptionsBalance = await feeToken.balanceOf(subscriptions.address)
+
+        const { amountToPay } = await subscriptions.getPayFeesDetails(subscriber, resumePaidPeriods)
+        assert.equal(amountToPay.toString(), expectedTotalPaidFees.toString(), 'amount to be paid does not match')
+
+        await subscriptions.payFees(subscriber, resumePaidPeriods, { from: payer })
+
+        const currentSubscriptionsBalance = await feeToken.balanceOf(subscriptions.address)
+        assert.equal(currentSubscriptionsBalance.toString(), previousSubscriptionsBalance.add(expectedTotalPaidFees).toString(), 'subscriptions balances do not match')
+
+        const currentPayerBalance = await feeToken.balanceOf(payer)
+        assert.equal(currentPayerBalance.toString(), previousPayerBalance.sub(expectedTotalPaidFees).toString(), 'payer balances do not match')
+      })
+
+      it('pays the governor fees', async () => {
+        const { newLastPeriodId } = await subscriptions.getPayFeesDetails(subscriber, resumePaidPeriods)
+        const previousGovernorFees = await subscriptions.accumulatedGovernorFees()
+
+        const receipt = await subscriptions.payFees(subscriber, resumePaidPeriods, { from: payer })
+
+        const currentGovernorFees = await subscriptions.accumulatedGovernorFees()
+        assert.equal(currentGovernorFees.toString(), previousGovernorFees.add(expectedGovernorFees).toString(), 'governor fees do not match')
+
+        const expectedCollectedFees = expectedTotalPaidFees.sub(expectedGovernorFees)
+        assertAmountOfEvents(receipt, 'FeesPaid')
+        assertEvent(receipt, 'FeesPaid', { subscriber, periods: resumePaidPeriods, newLastPeriodId, collectedFees: expectedCollectedFees, governorFee: expectedGovernorFees })
+      })
+    }
+
+    context('when the subscriber is up-to-date and has paid some periods in advance', () => {
+      const prePaidPeriods = 3
+
+      beforeEach('pay and pause', async () => {
+        await subscriptions.payFees(subscriber, prePaidPeriods, { from: payer })
+        await subscriptions.pause({ from: subscriber })
+
+        const { paused, previousDelayedPeriods } = await subscriptions.getSubscriber(subscriber)
+        assert.isTrue(paused, 'subscriber should be paused')
+        assert.equal(previousDelayedPeriods.toString(), 0, 'delayed periods does not match')
+      })
+
+      context('when the current period has not passed', () => {
+        const resumePaidPeriods = 5
+        const expectedMovedPeriods = resumePaidPeriods + prePaidPeriods
+        const expectedRegularPeriods = resumePaidPeriods
+        const expectedDelayedPeriods = 0
+
+        itIsUpToDate(resumePaidPeriods)
+        itComputesLastAndDelayedPeriodsCorrectly(resumePaidPeriods, expectedMovedPeriods, expectedDelayedPeriods)
+        itPaysNormalFees(resumePaidPeriods, expectedRegularPeriods, expectedDelayedPeriods)
+      })
+
+      context('when the current period has passed', () => {
+        const resumePaidPeriods = 5
+        const expectedMovedPeriods = resumePaidPeriods + prePaidPeriods - 1
+        const expectedRegularPeriods = resumePaidPeriods
+        const expectedDelayedPeriods = 0
+
+        beforeEach('advance 1 period', async () => {
+          await subscriptionsOwner.mockIncreaseTerms(PERIOD_DURATION)
+        })
+
+        itIsUpToDate(resumePaidPeriods)
+        itComputesLastAndDelayedPeriodsCorrectly(resumePaidPeriods, expectedMovedPeriods, expectedDelayedPeriods)
+        itPaysNormalFees(resumePaidPeriods, expectedRegularPeriods, expectedDelayedPeriods)
+      })
+
+      context('when the current period has passed up-to the pre-paid periods', () => {
+        const resumePaidPeriods = 5
+        const expectedMovedPeriods = resumePaidPeriods
+        const expectedRegularPeriods = resumePaidPeriods
+        const expectedDelayedPeriods = 0
+
+        beforeEach('advance up-to the pre-paid periods', async () => {
+          await subscriptionsOwner.mockIncreaseTerms(PERIOD_DURATION * prePaidPeriods)
+        })
+
+        itIsUpToDate(resumePaidPeriods)
+        itComputesLastAndDelayedPeriodsCorrectly(resumePaidPeriods, expectedMovedPeriods, expectedDelayedPeriods)
+        itPaysNormalFees(resumePaidPeriods, expectedRegularPeriods, expectedDelayedPeriods)
+      })
+
+      context('when the current period has passed the pre-paid periods by one period', () => {
+        const overduePeriods = 1
+        const resumePaidPeriods = 5
+        const expectedMovedPeriods = resumePaidPeriods - 1
+        const expectedRegularPeriods = resumePaidPeriods
+        const expectedDelayedPeriods = 0
+
+        beforeEach('pass the pre-paid periods', async () => {
+          await subscriptionsOwner.mockIncreaseTerms(PERIOD_DURATION * (prePaidPeriods + overduePeriods))
+        })
+
+        itIsUpToDate(resumePaidPeriods)
+        itComputesLastAndDelayedPeriodsCorrectly(resumePaidPeriods, expectedMovedPeriods, expectedDelayedPeriods)
+        itPaysNormalFees(resumePaidPeriods, expectedRegularPeriods, expectedDelayedPeriods)
+      })
+
+      context('when the current period has passed the pre-paid periods by more than one period', () => {
+        const overduePeriods = 2
+
+        beforeEach('pass the pre-paid periods', async () => {
+          await subscriptionsOwner.mockIncreaseTerms(PERIOD_DURATION * (prePaidPeriods + overduePeriods))
+        })
+
+        context('when paying less than the corresponding pre-paid periods', () => {
+          const resumePaidPeriods = RESUME_PRE_PAID_PERIODS - 1
+
+          it('reverts', async () => {
+            await assertRevert(subscriptions.payFees(subscriber, resumePaidPeriods, { from: payer }), 'CS_LOW_RESUME_PERIODS_PAYMENT')
+          })
+        })
+
+        context('when paying the corresponding pre-paid periods', () => {
+          const resumePaidPeriods = RESUME_PRE_PAID_PERIODS
+          const expectedMovedPeriods = resumePaidPeriods - 1
+          const expectedRegularPeriods = 0
+          const expectedDelayedPeriods = 0
+
+          itIsUpToDate(resumePaidPeriods)
+          itComputesLastAndDelayedPeriodsCorrectly(resumePaidPeriods, expectedMovedPeriods, expectedDelayedPeriods)
+          itPaysResumingFees(resumePaidPeriods, expectedRegularPeriods, expectedDelayedPeriods)
+        })
+
+        context('when paying the more than the corresponding pre-paid periods', () => {
+          const resumePaidPeriods = RESUME_PRE_PAID_PERIODS + 1
+          const expectedMovedPeriods = resumePaidPeriods - 1
+          const expectedRegularPeriods = 1
+          const expectedDelayedPeriods = 0
+
+          itIsUpToDate(resumePaidPeriods)
+          itComputesLastAndDelayedPeriodsCorrectly(resumePaidPeriods, expectedMovedPeriods, expectedDelayedPeriods)
+          itPaysResumingFees(resumePaidPeriods, expectedRegularPeriods, expectedDelayedPeriods)
+        })
+      })
+    })
+
+    context('when the subscriber is up-to-date and has not paid periods in advance', () => {
+      beforeEach('pause', async () => {
+        await subscriptions.pause({ from: subscriber })
+
+        const { paused, previousDelayedPeriods } = await subscriptions.getSubscriber(subscriber)
+        assert.isTrue(paused, 'subscriber should be paused')
+        assert.equal(previousDelayedPeriods.toString(), 0, 'delayed periods does not match')
+      })
+
+      context('when the current period has not passed', () => {
+        const resumePaidPeriods = 5
+        const expectedMovedPeriods = resumePaidPeriods
+        const expectedRegularPeriods = resumePaidPeriods
+        const expectedDelayedPeriods = 0
+
+        itIsUpToDate(resumePaidPeriods)
+        itComputesLastAndDelayedPeriodsCorrectly(resumePaidPeriods, expectedMovedPeriods, expectedDelayedPeriods)
+        itPaysNormalFees(resumePaidPeriods, expectedRegularPeriods, expectedDelayedPeriods)
+      })
+
+      context('when the current period has passed', () => {
+        const overduePeriods = 1
+        const resumePaidPeriods = 5
+        const expectedMovedPeriods = resumePaidPeriods - 1
+        const expectedRegularPeriods = resumePaidPeriods
+        const expectedDelayedPeriods = 0
+
+        beforeEach('advance 1 period', async () => {
+          await subscriptionsOwner.mockIncreaseTerms(PERIOD_DURATION * overduePeriods)
+        })
+
+        itIsUpToDate(resumePaidPeriods)
+        itComputesLastAndDelayedPeriodsCorrectly(resumePaidPeriods, expectedMovedPeriods, expectedDelayedPeriods)
+        itPaysNormalFees(resumePaidPeriods, expectedRegularPeriods, expectedDelayedPeriods)
+      })
+
+      context('when the current period has passed by more than one period', () => {
+        const overduePeriods = 2
+
+        beforeEach('pass the pre-paid periods', async () => {
+          await subscriptionsOwner.mockIncreaseTerms(PERIOD_DURATION * overduePeriods)
+        })
+
+        context('when paying less than the corresponding pre-paid periods', () => {
+          const resumePaidPeriods = RESUME_PRE_PAID_PERIODS - 1
+
+          it('reverts', async () => {
+            await assertRevert(subscriptions.payFees(subscriber, resumePaidPeriods, { from: payer }), 'CS_LOW_RESUME_PERIODS_PAYMENT')
+          })
+        })
+
+        context('when paying the corresponding pre-paid periods', () => {
+          const resumePaidPeriods = RESUME_PRE_PAID_PERIODS
+          const expectedMovedPeriods = resumePaidPeriods - 1
+          const expectedRegularPeriods = 0
+          const expectedDelayedPeriods = 0
+
+          itIsUpToDate(resumePaidPeriods)
+          itComputesLastAndDelayedPeriodsCorrectly(resumePaidPeriods, expectedMovedPeriods, expectedDelayedPeriods)
+          itPaysResumingFees(resumePaidPeriods, expectedRegularPeriods, expectedDelayedPeriods)
+        })
+
+        context('when paying the more than the corresponding pre-paid periods', () => {
+          const resumePaidPeriods = RESUME_PRE_PAID_PERIODS + 1
+          const expectedMovedPeriods = resumePaidPeriods - 1
+          const expectedRegularPeriods = 1
+          const expectedDelayedPeriods = 0
+
+          itIsUpToDate(resumePaidPeriods)
+          itComputesLastAndDelayedPeriodsCorrectly(resumePaidPeriods, expectedMovedPeriods, expectedDelayedPeriods)
+          itPaysResumingFees(resumePaidPeriods, expectedRegularPeriods, expectedDelayedPeriods)
+        })
+      })
+    })
+
+    context('when the subscriber has one overdue period', () => {
+      const overduePeriods = 1
+      const resumePaidPeriods = 5
+      const expectedMovedPeriods = resumePaidPeriods - 1
+      const expectedRegularPeriods = resumePaidPeriods
+      const expectedDelayedPeriods = 0
+
+      beforeEach('advance overdue periods and pause', async () => {
+        await subscriptionsOwner.mockIncreaseTerms(PERIOD_DURATION * overduePeriods)
+        await subscriptions.pause({ from: subscriber })
+
+        const { paused, previousDelayedPeriods } = await subscriptions.getSubscriber(subscriber)
+        assert.isTrue(paused, 'subscriber should be paused')
+        assert.equal(previousDelayedPeriods.toString(), 0, 'delayed periods does not match')
+      })
+
+      itIsUpToDate(resumePaidPeriods)
+      itComputesLastAndDelayedPeriodsCorrectly(resumePaidPeriods, expectedMovedPeriods, expectedDelayedPeriods)
+      itPaysNormalFees(resumePaidPeriods, expectedRegularPeriods, expectedDelayedPeriods)
+    })
+
+    context('when the subscriber has more than one overdue period', () => {
+      const delayedPeriods = 2
+      const overduePeriods = delayedPeriods + 1
+
+      beforeEach('advance overdue periods and pause', async () => {
+        await subscriptionsOwner.mockIncreaseTerms(PERIOD_DURATION * overduePeriods)
+        await subscriptions.pause({ from: subscriber })
+
+        const { paused, previousDelayedPeriods } = await subscriptions.getSubscriber(subscriber)
+        assert.isTrue(paused, 'subscriber should be paused')
+        assert.equal(previousDelayedPeriods.toString(), delayedPeriods, 'delayed periods does not match')
+      })
+
+      context('when paying less than the corresponding pre-paid periods', () => {
+        const resumePaidPeriods = RESUME_PRE_PAID_PERIODS - 1
+
+        it('reverts', async () => {
+          await assertRevert(subscriptions.payFees(subscriber, resumePaidPeriods, { from: payer }), 'CS_LOW_RESUME_PERIODS_PAYMENT')
+        })
+      })
+
+      context('when paying the corresponding pre-paid periods but not the delayed periods', () => {
+        const resumePaidPeriods = RESUME_PRE_PAID_PERIODS
+
+        it('reverts', async () => {
+          await assertRevert(subscriptions.payFees(subscriber, resumePaidPeriods, { from: payer }), 'CS_LOW_RESUME_PERIODS_PAYMENT')
+        })
+      })
+
+      context('when paying the corresponding pre-paid and delayed periods', () => {
+        const resumePaidPeriods = RESUME_PRE_PAID_PERIODS + delayedPeriods
+        const expectedMovedPeriods = resumePaidPeriods - 1
+        const expectedRegularPeriods = 0
+        const expectedDelayedPeriods = delayedPeriods
+
+        itIsUpToDate(resumePaidPeriods)
+        itComputesLastAndDelayedPeriodsCorrectly(resumePaidPeriods, expectedMovedPeriods, expectedDelayedPeriods)
+        itPaysResumingFees(resumePaidPeriods, expectedRegularPeriods, expectedDelayedPeriods)
+      })
+
+      context('when paying the more than the corresponding pre-paid and delayed periods', () => {
+        const resumePaidPeriods = RESUME_PRE_PAID_PERIODS + delayedPeriods + 1
+        const expectedMovedPeriods = resumePaidPeriods - 1
+        const expectedRegularPeriods = 1
+        const expectedDelayedPeriods = delayedPeriods
+
+        itIsUpToDate(resumePaidPeriods)
+        itComputesLastAndDelayedPeriodsCorrectly(resumePaidPeriods, expectedMovedPeriods, expectedDelayedPeriods)
+        itPaysResumingFees(resumePaidPeriods, expectedRegularPeriods, expectedDelayedPeriods)
+      })
+    })
+  })
+})

--- a/test/subscriptions/subscriptions-payments.js
+++ b/test/subscriptions/subscriptions-payments.js
@@ -13,6 +13,7 @@ contract('CourtSubscriptions', ([_, payer, subscriber, anotherSubscriber]) => {
   const PCT_BASE = bn(10000)
   const FEE_AMOUNT = bigExp(10, 18)
   const PREPAYMENT_PERIODS = 5
+  const RESUME_PRE_PAID_PERIODS = 1
   const PERIOD_DURATION = 24 * 30           // 30 days, assuming terms are 1h
   const GOVERNOR_SHARE_PCT = bn(100)        // 100‱ = 1%
   const LATE_PAYMENT_PENALTY_PCT = bn(1000) // 1000‱ = 10%
@@ -27,7 +28,7 @@ contract('CourtSubscriptions', ([_, payer, subscriber, anotherSubscriber]) => {
   describe('payFees', () => {
     context('when the subscriptions was already initialized', () => {
       beforeEach('initialize subscriptions', async () => {
-        await subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT)
+        await subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT)
       })
 
       context('when the number of periods is greater than zero', () => {
@@ -322,7 +323,7 @@ contract('CourtSubscriptions', ([_, payer, subscriber, anotherSubscriber]) => {
   describe('transferFeesToGovernor', () => {
     context('when the subscriptions was already initialized', () => {
       beforeEach('initialize subscriptions', async () => {
-        await subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT)
+        await subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT)
       })
 
       context('when there are no accumulated fees', () => {
@@ -379,7 +380,7 @@ contract('CourtSubscriptions', ([_, payer, subscriber, anotherSubscriber]) => {
   describe('isUpToDate', () => {
     context('when the subscriptions was already initialized', () => {
       beforeEach('initialize subscriptions', async () => {
-        await subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT)
+        await subscriptions.init(subscriptionsOwner.address, jurorsRegistry.address, PERIOD_DURATION, feeToken.address, FEE_AMOUNT, PREPAYMENT_PERIODS, RESUME_PRE_PAID_PERIODS, LATE_PAYMENT_PENALTY_PCT, GOVERNOR_SHARE_PCT)
       })
 
       context('when the subscriber was already subscribed', () => {


### PR DESCRIPTION
Fixes #133 

The idea is to introduce a number of periods that must be paid in advance in case a user pauses/resumes his subscription. To reduce complexity, when a user resumes his subscriptions, the user must pay all these periods at once (including the number of previous delayed periods)