### PR TITLE
Add description to Court test headers

### DIFF
--- a/test/court/court-appeal.js
+++ b/test/court/court-appeal.js
@@ -7,7 +7,7 @@ const { buildHelper, DEFAULTS, ROUND_STATES, DISPUTE_STATES } = require('../help
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
-contract('Court', ([_, disputer, drafter, appealMaker, appealTaker, juror500, juror1000, juror1500, juror2000, juror2500, juror3000, juror3500, juror4000]) => {
+contract('Court (appeal)', ([_, disputer, drafter, appealMaker, appealTaker, juror500, juror1000, juror1500, juror2000, juror2500, juror3000, juror3500, juror4000]) => {
   let courtHelper, court, voting
 
   const jurors = [
@@ -26,304 +26,199 @@ contract('Court', ([_, disputer, drafter, appealMaker, appealTaker, juror500, ju
     voting = courtHelper.voting
   })
 
-  describe('appeal', () => {
-    context('when the given dispute exists', () => {
-      let disputeId
-      const draftTermId = 4
+  context('when the given dispute exists', () => {
+    let disputeId
+    const draftTermId = 4
 
-      beforeEach('activate jurors and create dispute', async () => {
-        await courtHelper.activate(jurors)
+    beforeEach('activate jurors and create dispute', async () => {
+      await courtHelper.activate(jurors)
 
-        await courtHelper.setTerm(1)
-        disputeId = await courtHelper.dispute({ draftTermId, disputer })
-        await courtHelper.passTerms(bn(draftTermId - 1)) // court is already at term one
-      })
+      await courtHelper.setTerm(1)
+      disputeId = await courtHelper.dispute({ draftTermId, disputer })
+      await courtHelper.passTerms(bn(draftTermId - 1)) // court is already at term one
+    })
 
-      context('when the given round is valid', () => {
-        let voteId, voters, nonVoters
+    context('when the given round is valid', () => {
+      let voteId, voters, nonVoters
 
-        const itIsAtState = (roundId, state) => {
-          it(`round is at state ${state}`, async () => {
-            const { roundState } = await courtHelper.getRound(disputeId, roundId)
-            assert.equal(roundState.toString(), state.toString(), 'round state does not match')
-          })
-        }
+      const itIsAtState = (roundId, state) => {
+        it(`round is at state ${state}`, async () => {
+          const { roundState } = await courtHelper.getRound(disputeId, roundId)
+          assert.equal(roundState.toString(), state.toString(), 'round state does not match')
+        })
+      }
 
-        const itFailsToAppeal = (roundId) => {
-          it('fails to appeal', async () => {
-            await assertRevert(court.createAppeal(disputeId, roundId, OUTCOMES.REFUSED), 'CT_INVALID_ADJUDICATION_STATE')
-          })
-        }
+      const itFailsToAppeal = (roundId) => {
+        it('fails to appeal', async () => {
+          await assertRevert(court.createAppeal(disputeId, roundId, OUTCOMES.REFUSED), 'CT_INVALID_ADJUDICATION_STATE')
+        })
+      }
 
-        context('for a regular round', () => {
-          const roundId = 0
-          let draftedJurors, nonDraftedJurors
+      context('for a regular round', () => {
+        const roundId = 0
+        let draftedJurors, nonDraftedJurors
 
-          beforeEach('draft round', async () => {
-            draftedJurors = await courtHelper.draft({ disputeId, drafter })
-            nonDraftedJurors = jurors.filter(juror => !draftedJurors.map(j => j.address).includes(juror.address))
-          })
+        beforeEach('draft round', async () => {
+          draftedJurors = await courtHelper.draft({ disputeId, drafter })
+          nonDraftedJurors = jurors.filter(juror => !draftedJurors.map(j => j.address).includes(juror.address))
+        })
 
-          beforeEach('define a group of voters', async () => {
-            voteId = getVoteId(disputeId, roundId)
-            // pick the first 3 drafted jurors to vote
-            voters = draftedJurors.slice(0, 3)
-            voters.forEach((voter, i) => voter.outcome = outcomeFor(i))
-            nonVoters = filterJurors(draftedJurors, voters)
-          })
+        beforeEach('define a group of voters', async () => {
+          voteId = getVoteId(disputeId, roundId)
+          // pick the first 3 drafted jurors to vote
+          voters = draftedJurors.slice(0, 3)
+          voters.forEach((voter, i) => voter.outcome = outcomeFor(i))
+          nonVoters = filterJurors(draftedJurors, voters)
+        })
 
-          context('during commit period', () => {
-            itIsAtState(roundId, ROUND_STATES.COMMITTING)
-            itFailsToAppeal(roundId)
-          })
+        context('during commit period', () => {
+          itIsAtState(roundId, ROUND_STATES.COMMITTING)
+          itFailsToAppeal(roundId)
+        })
 
-          context('during reveal period', () => {
-            beforeEach('commit votes', async () => {
-              await courtHelper.commit({ disputeId, roundId, voters })
-            })
-
-            itIsAtState(roundId, ROUND_STATES.REVEALING)
-            itFailsToAppeal(roundId)
+        context('during reveal period', () => {
+          beforeEach('commit votes', async () => {
+            await courtHelper.commit({ disputeId, roundId, voters })
           })
 
-          context('during appeal period', () => {
-            let winningRuling
+          itIsAtState(roundId, ROUND_STATES.REVEALING)
+          itFailsToAppeal(roundId)
+        })
 
-            beforeEach('commit and reveal votes', async () => {
-              await courtHelper.commit({ disputeId, roundId, voters })
-              await courtHelper.reveal({ disputeId, roundId, voters })
+        context('during appeal period', () => {
+          let winningRuling
 
-              winningRuling = await voting.getWinningOutcome(voteId)
-            })
+          beforeEach('commit and reveal votes', async () => {
+            await courtHelper.commit({ disputeId, roundId, voters })
+            await courtHelper.reveal({ disputeId, roundId, voters })
 
-            itIsAtState(roundId, ROUND_STATES.APPEALING)
+            winningRuling = await voting.getWinningOutcome(voteId)
+          })
 
-            context('when the appeal ruling is valid', () => {
-              let appealMakerRuling
+          itIsAtState(roundId, ROUND_STATES.APPEALING)
 
-              context('when the appeal ruling is different from the winning one', () => {
-                beforeEach('set confirmed ruling', async () => {
-                  appealMakerRuling = oppositeOutcome(winningRuling)
+          context('when the appeal ruling is valid', () => {
+            let appealMakerRuling
+
+            context('when the appeal ruling is different from the winning one', () => {
+              beforeEach('set confirmed ruling', async () => {
+                appealMakerRuling = oppositeOutcome(winningRuling)
+              })
+
+              context('when the appeal maker has enough balance', () => {
+                beforeEach('mint fee tokens for appeal maker', async () => {
+                  const { appealDeposit } = await courtHelper.getAppealFees(disputeId, roundId)
+                  await courtHelper.mintAndApproveFeeTokens(appealMaker, court.address, appealDeposit)
                 })
 
-                context('when the appeal maker has enough balance', () => {
-                  beforeEach('mint fee tokens for appeal maker', async () => {
-                    const { appealDeposit } = await courtHelper.getAppealFees(disputeId, roundId)
-                    await courtHelper.mintAndApproveFeeTokens(appealMaker, court.address, appealDeposit)
-                  })
+                it('emits an event', async () => {
+                  const receipt = await court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker })
 
-                  it('emits an event', async () => {
-                    const receipt = await court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker })
-
-                    assertAmountOfEvents(receipt, 'RulingAppealed')
-                    assertEvent(receipt, 'RulingAppealed', { disputeId, roundId, ruling: appealMakerRuling })
-                  })
-
-                  it('appeals the given round', async () => {
-                    await court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker })
-
-                    const { appealer, appealedRuling, taker, opposedRuling } = await courtHelper.getAppeal(disputeId, roundId)
-                    assert.equal(appealer, appealMaker, 'appeal maker does not match')
-                    assert.equal(appealedRuling.toString(), appealMakerRuling, 'appealed ruling does not match')
-                    assert.equal(taker.toString(), ZERO_ADDRESS, 'appeal taker does not match')
-                    assert.equal(opposedRuling.toString(), 0, 'opposed ruling does not match')
-                  })
-
-                  it('transfers the appeal deposit to the court', async () => {
-                    const { accounting, feeToken } = courtHelper
-                    const { appealDeposit } = await courtHelper.getAppealFees(disputeId, roundId)
-
-                    const previousCourtBalance = await feeToken.balanceOf(court.address)
-                    const previousAccountingBalance = await feeToken.balanceOf(accounting.address)
-                    const previousAppealerBalance = await feeToken.balanceOf(appealMaker)
-
-                    await court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker })
-
-                    const currentCourtBalance = await feeToken.balanceOf(court.address)
-                    assert.equal(previousCourtBalance.toString(), currentCourtBalance.toString(), 'court balances do not match')
-
-                    const currentAccountingBalance = await feeToken.balanceOf(accounting.address)
-                    assert.equal(previousAccountingBalance.add(appealDeposit).toString(), currentAccountingBalance.toString(), 'court accounting balances do not match')
-
-                    const currentAppealerBalance = await feeToken.balanceOf(appealMaker)
-                    assert.equal(previousAppealerBalance.sub(appealDeposit).toString(), currentAppealerBalance.toString(), 'sender balances do not match')
-                  })
-
-                  it('does not create a new round for the dispute', async () => {
-                    await court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker })
-
-                    await assertRevert(court.getRound(disputeId, roundId + 1), 'CT_ROUND_DOES_NOT_EXIST')
-                  })
-
-                  it('does not modify the current round of the dispute', async () => {
-                    await court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker })
-
-                    const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, triggeredBy, jurorFees, settledPenalties, collectedTokens } = await courtHelper.getRound(disputeId, roundId)
-                    assert.equal(draftTerm.toString(), draftTermId, 'current round draft term does not match')
-                    assert.equal(delayedTerms.toString(), 0, 'current round delay term does not match')
-                    assert.equal(roundJurorsNumber.toString(), DEFAULTS.firstRoundJurorsNumber, 'current round jurors number does not match')
-                    assert.equal(selectedJurors.toString(), DEFAULTS.firstRoundJurorsNumber, 'current round selected jurors number does not match')
-                    assert.equal(jurorFees.toString(), courtHelper.jurorFee.mul(bn(DEFAULTS.firstRoundJurorsNumber)).toString(), 'current round juror fees do not match')
-                    assert.equal(triggeredBy, disputer, 'current round trigger does not match')
-                    assert.equal(settledPenalties, false, 'current round penalties should not be settled')
-                    assert.equal(collectedTokens.toString(), 0, 'current round collected tokens should be zero')
-                  })
-
-                  it('does not modify core dispute information', async () => {
-                    await court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker })
-
-                    const { possibleRulings, state, finalRuling } = await courtHelper.getDispute(disputeId)
-                    assert.equal(state.toString(), DISPUTE_STATES.ADJUDICATING.toString(), 'dispute state does not match')
-                    assert.equal(possibleRulings.toString(), 2, 'dispute possible rulings do not match')
-                    assert.equal(finalRuling.toString(), 0, 'dispute final ruling does not match')
-                  })
-
-                  it('cannot be appealed twice', async () => {
-                    await court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker })
-
-                    await assertRevert(court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker }), 'CT_INVALID_ADJUDICATION_STATE')
-                  })
+                  assertAmountOfEvents(receipt, 'RulingAppealed')
+                  assertEvent(receipt, 'RulingAppealed', { disputeId, roundId, ruling: appealMakerRuling })
                 })
 
-                context('when the appeal maker does not have enough balance', () => {
-                  it('reverts', async () => {
-                    await assertRevert(court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker }), 'CT_DEPOSIT_FAILED')
-                  })
+                it('appeals the given round', async () => {
+                  await court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker })
+
+                  const { appealer, appealedRuling, taker, opposedRuling } = await courtHelper.getAppeal(disputeId, roundId)
+                  assert.equal(appealer, appealMaker, 'appeal maker does not match')
+                  assert.equal(appealedRuling.toString(), appealMakerRuling, 'appealed ruling does not match')
+                  assert.equal(taker.toString(), ZERO_ADDRESS, 'appeal taker does not match')
+                  assert.equal(opposedRuling.toString(), 0, 'opposed ruling does not match')
+                })
+
+                it('transfers the appeal deposit to the court', async () => {
+                  const { accounting, feeToken } = courtHelper
+                  const { appealDeposit } = await courtHelper.getAppealFees(disputeId, roundId)
+
+                  const previousCourtBalance = await feeToken.balanceOf(court.address)
+                  const previousAccountingBalance = await feeToken.balanceOf(accounting.address)
+                  const previousAppealerBalance = await feeToken.balanceOf(appealMaker)
+
+                  await court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker })
+
+                  const currentCourtBalance = await feeToken.balanceOf(court.address)
+                  assert.equal(previousCourtBalance.toString(), currentCourtBalance.toString(), 'court balances do not match')
+
+                  const currentAccountingBalance = await feeToken.balanceOf(accounting.address)
+                  assert.equal(previousAccountingBalance.add(appealDeposit).toString(), currentAccountingBalance.toString(), 'court accounting balances do not match')
+
+                  const currentAppealerBalance = await feeToken.balanceOf(appealMaker)
+                  assert.equal(previousAppealerBalance.sub(appealDeposit).toString(), currentAppealerBalance.toString(), 'sender balances do not match')
+                })
+
+                it('does not create a new round for the dispute', async () => {
+                  await court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker })
+
+                  await assertRevert(court.getRound(disputeId, roundId + 1), 'CT_ROUND_DOES_NOT_EXIST')
+                })
+
+                it('does not modify the current round of the dispute', async () => {
+                  await court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker })
+
+                  const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, triggeredBy, jurorFees, settledPenalties, collectedTokens } = await courtHelper.getRound(disputeId, roundId)
+                  assert.equal(draftTerm.toString(), draftTermId, 'current round draft term does not match')
+                  assert.equal(delayedTerms.toString(), 0, 'current round delay term does not match')
+                  assert.equal(roundJurorsNumber.toString(), DEFAULTS.firstRoundJurorsNumber, 'current round jurors number does not match')
+                  assert.equal(selectedJurors.toString(), DEFAULTS.firstRoundJurorsNumber, 'current round selected jurors number does not match')
+                  assert.equal(jurorFees.toString(), courtHelper.jurorFee.mul(bn(DEFAULTS.firstRoundJurorsNumber)).toString(), 'current round juror fees do not match')
+                  assert.equal(triggeredBy, disputer, 'current round trigger does not match')
+                  assert.equal(settledPenalties, false, 'current round penalties should not be settled')
+                  assert.equal(collectedTokens.toString(), 0, 'current round collected tokens should be zero')
+                })
+
+                it('does not modify core dispute information', async () => {
+                  await court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker })
+
+                  const { possibleRulings, state, finalRuling } = await courtHelper.getDispute(disputeId)
+                  assert.equal(state.toString(), DISPUTE_STATES.ADJUDICATING.toString(), 'dispute state does not match')
+                  assert.equal(possibleRulings.toString(), 2, 'dispute possible rulings do not match')
+                  assert.equal(finalRuling.toString(), 0, 'dispute final ruling does not match')
+                })
+
+                it('cannot be appealed twice', async () => {
+                  await court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker })
+
+                  await assertRevert(court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker }), 'CT_INVALID_ADJUDICATION_STATE')
                 })
               })
 
-              context('when the appeal ruling is equal to the winning one', () => {
-                beforeEach('set confirmed ruling', async () => {
-                  appealMakerRuling = winningRuling
-                })
-
+              context('when the appeal maker does not have enough balance', () => {
                 it('reverts', async () => {
-                  await assertRevert(court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker }), 'CT_INVALID_APPEAL_RULING')
+                  await assertRevert(court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker }), 'CT_DEPOSIT_FAILED')
                 })
               })
             })
 
-            context('when the appeal ruling is not valid', () => {
-              const invalidRuling = 10
+            context('when the appeal ruling is equal to the winning one', () => {
+              beforeEach('set confirmed ruling', async () => {
+                appealMakerRuling = winningRuling
+              })
 
               it('reverts', async () => {
-                await assertRevert(court.createAppeal(disputeId, roundId, invalidRuling, { from: appealMaker }), 'CT_INVALID_APPEAL_RULING')
+                await assertRevert(court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker }), 'CT_INVALID_APPEAL_RULING')
               })
             })
           })
 
-          context('during the appeal confirmation period', () => {
-            beforeEach('commit and reveal votes', async () => {
-              await courtHelper.commit({ disputeId, roundId, voters })
-              await courtHelper.reveal({ disputeId, roundId, voters })
-            })
+          context('when the appeal ruling is not valid', () => {
+            const invalidRuling = 10
 
-            context('when the round was not appealed', () => {
-              beforeEach('pass appeal period', async () => {
-                await courtHelper.passTerms(courtHelper.appealTerms)
-              })
-
-              itIsAtState(roundId, ROUND_STATES.ENDED)
-              itFailsToAppeal(roundId)
-            })
-
-            context('when the round was appealed', () => {
-              beforeEach('appeal', async () => {
-                await courtHelper.appeal({ disputeId, roundId, appealMaker })
-              })
-
-              itIsAtState(roundId, ROUND_STATES.CONFIRMING_APPEAL)
-              itFailsToAppeal(roundId)
-            })
-          })
-
-          context('after the appeal confirmation period', () => {
-            beforeEach('commit and reveal votes', async () => {
-              await courtHelper.commit({ disputeId, roundId, voters })
-              await courtHelper.reveal({ disputeId, roundId, voters })
-            })
-
-            context('when the round was not appealed', () => {
-              beforeEach('pass appeal and confirmation periods', async () => {
-                await courtHelper.passTerms(courtHelper.appealTerms.add(courtHelper.appealConfirmTerms))
-              })
-
-              itIsAtState(roundId, ROUND_STATES.ENDED)
-              itFailsToAppeal(roundId)
-            })
-
-            context('when the round was appealed', () => {
-              beforeEach('appeal', async () => {
-                await courtHelper.appeal({ disputeId, roundId, appealMaker })
-              })
-
-              context('when the appeal was not confirmed', () => {
-                beforeEach('pass confirmation period', async () => {
-                  await courtHelper.passTerms(courtHelper.appealConfirmTerms)
-                })
-
-                itIsAtState(roundId, ROUND_STATES.ENDED)
-                itFailsToAppeal(roundId)
-              })
-
-              context('when the appeal was confirmed', () => {
-                beforeEach('confirm appeal', async () => {
-                  await courtHelper.confirmAppeal({ disputeId, roundId, appealTaker })
-                })
-
-                itIsAtState(roundId, ROUND_STATES.ENDED)
-                itFailsToAppeal(roundId)
-              })
+            it('reverts', async () => {
+              await assertRevert(court.createAppeal(disputeId, roundId, invalidRuling, { from: appealMaker }), 'CT_INVALID_APPEAL_RULING')
             })
           })
         })
 
-        context('for a final round', () => {
-          const roundId = DEFAULTS.maxRegularAppealRounds.toNumber()
-
-          beforeEach('move to final round', async () => {
-            await courtHelper.moveToFinalRound({ disputeId })
+        context('during the appeal confirmation period', () => {
+          beforeEach('commit and reveal votes', async () => {
+            await courtHelper.commit({ disputeId, roundId, voters })
+            await courtHelper.reveal({ disputeId, roundId, voters })
           })
 
-          beforeEach('define a group of voters', async () => {
-            voteId = getVoteId(disputeId, roundId)
-            voters = [
-              { address: juror1000, outcome: OUTCOMES.LOW },
-              { address: juror4000, outcome: OUTCOMES.LOW },
-              { address: juror2000, outcome: OUTCOMES.HIGH },
-              { address: juror1500, outcome: OUTCOMES.REFUSED },
-            ]
-            nonVoters = filterJurors(jurors, voters)
-          })
-
-          context('during commit period', () => {
-            itIsAtState(roundId, ROUND_STATES.COMMITTING)
-            itFailsToAppeal(roundId)
-          })
-
-          context('during reveal period', () => {
-            beforeEach('commit votes', async () => {
-              await courtHelper.commit({ disputeId, roundId, voters })
-            })
-
-            itIsAtState(roundId, ROUND_STATES.REVEALING)
-            itFailsToAppeal(roundId)
-          })
-
-          context('during appeal period', () => {
-            beforeEach('commit and reveal votes', async () => {
-              await courtHelper.commit({ disputeId, roundId, voters })
-              await courtHelper.reveal({ disputeId, roundId, voters })
-            })
-
-            itIsAtState(roundId, ROUND_STATES.ENDED)
-            itFailsToAppeal(roundId)
-          })
-
-          context('during the appeal confirmation period', () => {
-            beforeEach('commit and reveal votes, and pass appeal period', async () => {
-              await courtHelper.commit({ disputeId, roundId, voters })
-              await courtHelper.reveal({ disputeId, roundId, voters })
+          context('when the round was not appealed', () => {
+            beforeEach('pass appeal period', async () => {
               await courtHelper.passTerms(courtHelper.appealTerms)
             })
 
@@ -331,32 +226,135 @@ contract('Court', ([_, disputer, drafter, appealMaker, appealTaker, juror500, ju
             itFailsToAppeal(roundId)
           })
 
-          context('after the appeal confirmation period', () => {
-            beforeEach('commit and reveal votes, and pass appeal and confirmation periods', async () => {
-              await courtHelper.commit({ disputeId, roundId, voters })
-              await courtHelper.reveal({ disputeId, roundId, voters })
+          context('when the round was appealed', () => {
+            beforeEach('appeal', async () => {
+              await courtHelper.appeal({ disputeId, roundId, appealMaker })
+            })
+
+            itIsAtState(roundId, ROUND_STATES.CONFIRMING_APPEAL)
+            itFailsToAppeal(roundId)
+          })
+        })
+
+        context('after the appeal confirmation period', () => {
+          beforeEach('commit and reveal votes', async () => {
+            await courtHelper.commit({ disputeId, roundId, voters })
+            await courtHelper.reveal({ disputeId, roundId, voters })
+          })
+
+          context('when the round was not appealed', () => {
+            beforeEach('pass appeal and confirmation periods', async () => {
               await courtHelper.passTerms(courtHelper.appealTerms.add(courtHelper.appealConfirmTerms))
             })
 
             itIsAtState(roundId, ROUND_STATES.ENDED)
             itFailsToAppeal(roundId)
           })
+
+          context('when the round was appealed', () => {
+            beforeEach('appeal', async () => {
+              await courtHelper.appeal({ disputeId, roundId, appealMaker })
+            })
+
+            context('when the appeal was not confirmed', () => {
+              beforeEach('pass confirmation period', async () => {
+                await courtHelper.passTerms(courtHelper.appealConfirmTerms)
+              })
+
+              itIsAtState(roundId, ROUND_STATES.ENDED)
+              itFailsToAppeal(roundId)
+            })
+
+            context('when the appeal was confirmed', () => {
+              beforeEach('confirm appeal', async () => {
+                await courtHelper.confirmAppeal({ disputeId, roundId, appealTaker })
+              })
+
+              itIsAtState(roundId, ROUND_STATES.ENDED)
+              itFailsToAppeal(roundId)
+            })
+          })
         })
       })
 
-      context('when the given round is not valid', () => {
-        const roundId = 5
+      context('for a final round', () => {
+        const roundId = DEFAULTS.maxRegularAppealRounds.toNumber()
 
-        it('reverts', async () => {
-          await assertRevert(court.createAppeal(disputeId, roundId, OUTCOMES.LOW), 'CT_ROUND_DOES_NOT_EXIST')
+        beforeEach('move to final round', async () => {
+          await courtHelper.moveToFinalRound({ disputeId })
+        })
+
+        beforeEach('define a group of voters', async () => {
+          voteId = getVoteId(disputeId, roundId)
+          voters = [
+            { address: juror1000, outcome: OUTCOMES.LOW },
+            { address: juror4000, outcome: OUTCOMES.LOW },
+            { address: juror2000, outcome: OUTCOMES.HIGH },
+            { address: juror1500, outcome: OUTCOMES.REFUSED },
+          ]
+          nonVoters = filterJurors(jurors, voters)
+        })
+
+        context('during commit period', () => {
+          itIsAtState(roundId, ROUND_STATES.COMMITTING)
+          itFailsToAppeal(roundId)
+        })
+
+        context('during reveal period', () => {
+          beforeEach('commit votes', async () => {
+            await courtHelper.commit({ disputeId, roundId, voters })
+          })
+
+          itIsAtState(roundId, ROUND_STATES.REVEALING)
+          itFailsToAppeal(roundId)
+        })
+
+        context('during appeal period', () => {
+          beforeEach('commit and reveal votes', async () => {
+            await courtHelper.commit({ disputeId, roundId, voters })
+            await courtHelper.reveal({ disputeId, roundId, voters })
+          })
+
+          itIsAtState(roundId, ROUND_STATES.ENDED)
+          itFailsToAppeal(roundId)
+        })
+
+        context('during the appeal confirmation period', () => {
+          beforeEach('commit and reveal votes, and pass appeal period', async () => {
+            await courtHelper.commit({ disputeId, roundId, voters })
+            await courtHelper.reveal({ disputeId, roundId, voters })
+            await courtHelper.passTerms(courtHelper.appealTerms)
+          })
+
+          itIsAtState(roundId, ROUND_STATES.ENDED)
+          itFailsToAppeal(roundId)
+        })
+
+        context('after the appeal confirmation period', () => {
+          beforeEach('commit and reveal votes, and pass appeal and confirmation periods', async () => {
+            await courtHelper.commit({ disputeId, roundId, voters })
+            await courtHelper.reveal({ disputeId, roundId, voters })
+            await courtHelper.passTerms(courtHelper.appealTerms.add(courtHelper.appealConfirmTerms))
+          })
+
+          itIsAtState(roundId, ROUND_STATES.ENDED)
+          itFailsToAppeal(roundId)
         })
       })
     })
 
-    context('when the given dispute does not exist', () => {
+    context('when the given round is not valid', () => {
+      const roundId = 5
+
       it('reverts', async () => {
-        await assertRevert(court.createAppeal(0, 0, OUTCOMES.LOW), 'CT_DISPUTE_DOES_NOT_EXIST')
+        await assertRevert(court.createAppeal(disputeId, roundId, OUTCOMES.LOW), 'CT_ROUND_DOES_NOT_EXIST')
       })
+    })
+  })
+
+  context('when the given dispute does not exist', () => {
+    it('reverts', async () => {
+      await assertRevert(court.createAppeal(0, 0, OUTCOMES.LOW), 'CT_DISPUTE_DOES_NOT_EXIST')
     })
   })
 })

--- a/test/court/court-confirm-appeal.js
+++ b/test/court/court-confirm-appeal.js
@@ -5,7 +5,7 @@ const { assertAmountOfEvents, assertEvent } = require('../helpers/assertEvent')
 const { getVoteId, oppositeOutcome, outcomeFor, OUTCOMES } = require('../helpers/crvoting')
 const { buildHelper, DEFAULTS, ROUND_STATES, DISPUTE_STATES } = require('../helpers/court')(web3, artifacts)
 
-contract('Court', ([_, disputer, drafter, appealMaker, appealTaker, juror500, juror1000, juror1500, juror2000, juror2500, juror3000, juror3500, juror4000]) => {
+contract('Court (confirm appeal)', ([_, disputer, drafter, appealMaker, appealTaker, juror500, juror1000, juror1500, juror2000, juror2500, juror3000, juror3500, juror4000]) => {
   let courtHelper, court, voting
 
   const jurors = [
@@ -25,421 +25,419 @@ contract('Court', ([_, disputer, drafter, appealMaker, appealTaker, juror500, ju
     voting = courtHelper.voting
   })
 
-  describe('confirmAppeal', () => {
-    context('when the given dispute exists', () => {
-      let disputeId
-      const draftTermId = 4
-
-      beforeEach('activate jurors and create dispute', async () => {
-        await courtHelper.activate(jurors)
-
-        await courtHelper.setTerm(1)
-        disputeId = await courtHelper.dispute({ draftTermId, disputer })
-        await courtHelper.passTerms(bn(draftTermId - 1)) // court is already at term one
-      })
-
-      context('when the given round is valid', () => {
-        let voteId, voters, nonVoters
-
-        const itIsAtState = (roundId, state) => {
-          it(`round is at state ${state}`, async () => {
-            const { roundState } = await courtHelper.getRound(disputeId, roundId)
-            assert.equal(roundState.toString(), state.toString(), 'round state does not match')
-          })
-        }
-
-        const itFailsToConfirmAppeal = (roundId, reason = 'CT_INVALID_ADJUDICATION_STATE') => {
-          it('fails to confirm appeals', async () => {
-            await assertRevert(court.confirmAppeal(disputeId, roundId, OUTCOMES.REFUSED), reason)
-          })
-        }
-
-        context('for a regular round', () => {
-          const roundId = 0
-          let draftedJurors, nonDraftedJurors
-
-          beforeEach('draft round', async () => {
-            draftedJurors = await courtHelper.draft({ disputeId, drafter })
-            nonDraftedJurors = jurors.filter(juror => !draftedJurors.map(j => j.address).includes(juror.address))
-          })
-
-          beforeEach('define a group of voters', async () => {
-            voteId = getVoteId(disputeId, roundId)
-            // pick the first 3 drafted jurors to vote
-            voters = draftedJurors.slice(0, 3)
-            voters.forEach((voter, i) => voter.outcome = outcomeFor(i))
-            nonVoters = filterJurors(draftedJurors, voters)
-          })
-
-          context('during commit period', () => {
-            itIsAtState(roundId, ROUND_STATES.COMMITTING)
-            itFailsToConfirmAppeal(roundId)
-          })
-
-          context('during reveal period', () => {
-            beforeEach('commit votes', async () => {
-              await courtHelper.commit({ disputeId, roundId, voters })
-            })
-
-            itIsAtState(roundId, ROUND_STATES.REVEALING)
-            itFailsToConfirmAppeal(roundId)
-          })
-
-          context('during appeal period', () => {
-            beforeEach('commit and reveal votes', async () => {
-              await courtHelper.commit({ disputeId, roundId, voters })
-              await courtHelper.reveal({ disputeId, roundId, voters })
-            })
-
-            itIsAtState(roundId, ROUND_STATES.APPEALING)
-            itFailsToConfirmAppeal(roundId)
-          })
-
-          context('during the appeal confirmation period', () => {
-            beforeEach('commit and reveal votes', async () => {
-              await courtHelper.commit({ disputeId, roundId, voters })
-              await courtHelper.reveal({ disputeId, roundId, voters })
-            })
-
-            context('when the round was not appealed', () => {
-              beforeEach('pass appeal period', async () => {
-                await courtHelper.passTerms(courtHelper.appealTerms)
-              })
-
-              itIsAtState(roundId, ROUND_STATES.ENDED)
-              itFailsToConfirmAppeal(roundId)
-            })
-
-            context('when the round was appealed', () => {
-              let appealMakerRuling
-
-              beforeEach('appeal and move to appeal confirmation period', async () => {
-                await courtHelper.appeal({ disputeId, roundId, appealMaker })
-                const { appealedRuling } = await courtHelper.getAppeal(disputeId, roundId)
-                appealMakerRuling = appealedRuling
-              })
-
-              context('when the confirmed ruling is valid', () => {
-                let appealTakerRuling
-
-                context('when the confirmed ruling is different from the appealed one', () => {
-                  beforeEach('set confirmed ruling', async () => {
-                    appealTakerRuling = oppositeOutcome(appealMakerRuling)
-                  })
-
-                  context('when the appeal taker has enough balance', () => {
-                    beforeEach('mint fee tokens for appeal taker', async () => {
-                      const { confirmAppealDeposit } = await courtHelper.getAppealFees(disputeId, roundId)
-                      await courtHelper.mintAndApproveFeeTokens(appealTaker, court.address, confirmAppealDeposit)
-                    })
-
-                    const itCreatesNewRoundSuccessfully = roundId => {
-                      it('computes next round details successfully', async () => {
-                        const { nextRoundStartTerm, nextRoundJurorsNumber, newDisputeState, feeToken, totalFees, jurorFees, appealDeposit, confirmAppealDeposit } = await court.getNextRoundDetails(disputeId, roundId)
-
-                        const expectedStartTerm = await courtHelper.getNextRoundStartTerm(disputeId, roundId)
-                        assert.equal(nextRoundStartTerm.toString(), expectedStartTerm.toString(), 'next round start term does not match')
-
-                        const expectedJurorsNumber = await courtHelper.getNextRoundJurorsNumber(disputeId, roundId)
-                        assert.equal(nextRoundJurorsNumber.toString(), expectedJurorsNumber.toString(), 'next round jurors number does not match')
-
-                        const expectedDisputeState = (roundId < courtHelper.maxRegularAppealRounds.toNumber() - 1) ? DISPUTE_STATES.PRE_DRAFT : DISPUTE_STATES.ADJUDICATING
-                        assert.equal(newDisputeState.toString(), expectedDisputeState.toString(), 'next round jurors number does not match')
-
-                        const expectedJurorFees = await courtHelper.getNextRoundJurorFees(disputeId, roundId)
-                        assert.equal(jurorFees.toString(), expectedJurorFees.toString(), 'juror fees does not match')
-
-                        const { appealFees, appealDeposit: expectedAppealDeposit, confirmAppealDeposit: expectedConfirmAppealDeposit } = await courtHelper.getAppealFees(disputeId, roundId)
-                        assert.equal(feeToken, courtHelper.feeToken.address, 'fee token does not match')
-                        assert.equal(totalFees.toString(), appealFees.toString(), 'appeal fees does not match')
-                        assert.equal(appealDeposit.toString(), expectedAppealDeposit.toString(), 'appeal deposit does not match')
-                        assert.equal(confirmAppealDeposit.toString(), expectedConfirmAppealDeposit.toString(), 'confirm appeal deposit does not match')
-                      })
-
-                      it('computes final jurors number nevertheless the court current term', async () => {
-                        const previousTermId = await court.getCurrentTermId()
-                        const previousActiveBalance = await courtHelper.jurorsRegistry.totalActiveBalanceAt(previousTermId)
-                        const previousJurorsNumber = await courtHelper.getNextRoundJurorsNumber(disputeId, roundId)
-
-                        await courtHelper.passTerms(bn(1))
-                        await courtHelper.activate(jurors)
-                        await courtHelper.passTerms(bn(1))
-
-                        const currentTermId = await court.getCurrentTermId()
-                        const currentActiveBalance = await courtHelper.jurorsRegistry.totalActiveBalanceAt(currentTermId)
-                        assert.equal(currentActiveBalance.toString(), previousActiveBalance.mul(bn(2)).toString(), 'new total active balance does not match')
-
-                        const currentJurorsNumber = await courtHelper.getNextRoundJurorsNumber(disputeId, roundId)
-                        assert.equal(previousJurorsNumber.toString(), currentJurorsNumber.toString(), 'next round jurors number does not match')
-                      })
-
-                      it('emits an event', async () => {
-                        const receipt = await court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker })
-
-                        assertAmountOfEvents(receipt, 'RulingAppealConfirmed')
-
-                        const nextRoundStartTerm = await courtHelper.getNextRoundStartTerm(disputeId, roundId)
-                        const nextRoundJurorsNumber = await courtHelper.getNextRoundJurorsNumber(disputeId, roundId)
-                        assertEvent(receipt, 'RulingAppealConfirmed', {
-                          disputeId,
-                          roundId: roundId + 1,
-                          draftTermId: nextRoundStartTerm,
-                          jurorsNumber: nextRoundJurorsNumber
-                        })
-                      })
-
-                      it('confirms the given appealed round', async () => {
-                        await court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker })
-
-                        const { appealer, appealedRuling, taker, opposedRuling } = await courtHelper.getAppeal(disputeId, roundId)
-                        assert.equal(appealer, appealMaker, 'appeal maker does not match')
-                        assert.equal(appealedRuling.toString(), appealMakerRuling, 'appealed ruling does not match')
-                        assert.equal(taker.toString(), appealTaker, 'appeal taker does not match')
-                        assert.equal(opposedRuling.toString(), appealTakerRuling, 'opposed ruling does not match')
-                      })
-
-                      it('creates a new round for the given dispute', async () => {
-                        await court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker })
-
-                        const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, triggeredBy, settledPenalties, jurorFees, collectedTokens } = await courtHelper.getRound(disputeId, roundId + 1)
-
-                        const nextRoundStartTerm = await courtHelper.getNextRoundStartTerm(disputeId, roundId)
-                        assert.equal(draftTerm.toString(), nextRoundStartTerm.toString(), 'new round draft term does not match')
-                        assert.equal(delayedTerms.toString(), 0, 'new round delay term does not match')
-
-                        const nextRoundJurorsNumber = await courtHelper.getNextRoundJurorsNumber(disputeId, roundId)
-                        assert.equal(roundJurorsNumber.toString(), nextRoundJurorsNumber.toString(), 'new round jurors number does not match')
-
-                        const nextRoundJurorFees = await courtHelper.getNextRoundJurorFees(disputeId, roundId)
-                        assert.equal(jurorFees.toString(), nextRoundJurorFees.toString(), 'new round juror fees do not match')
-
-                        assert.equal(selectedJurors.toString(), 0, 'new round selected jurors number does not match')
-                        assert.equal(triggeredBy, appealTaker, 'new round trigger does not match')
-                        assert.equal(settledPenalties, false, 'new round penalties should not be settled')
-                        assert.equal(collectedTokens.toString(), 0, 'new round collected tokens should be zero')
-                      })
-
-                      it('does not modify the current round of the dispute', async () => {
-                        const { draftTerm: previousDraftTerm, delayedTerms: previousDelayedTerms, roundJurorsNumber: previousJurorsNumber, jurorFees: previousJurorFees, triggeredBy: previousTriggeredBy } = await courtHelper.getRound(disputeId, roundId)
-
-                        await court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker })
-
-                        const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, jurorFees, triggeredBy, settledPenalties, collectedTokens } = await courtHelper.getRound(disputeId, roundId)
-                        assert.equal(draftTerm.toString(), previousDraftTerm.toString(), 'current round draft term does not match')
-                        assert.equal(delayedTerms.toString(), previousDelayedTerms.toString(), 'current round delay term does not match')
-                        assert.equal(roundJurorsNumber.toString(), previousJurorsNumber.toString(), 'current round jurors number does not match')
-                        assert.equal(selectedJurors.toString(), previousJurorsNumber.toString(), 'current round selected jurors number does not match')
-                        assert.equal(jurorFees.toString(), previousJurorFees.toString(), 'current round juror fees do not match')
-                        assert.equal(triggeredBy, previousTriggeredBy, 'current round trigger does not match')
-                        assert.equal(settledPenalties, false, 'current round penalties should not be settled')
-                        assert.equal(collectedTokens.toString(), 0, 'current round collected tokens should be zero')
-                      })
-
-                      it('updates the dispute state', async () => {
-                        await court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker })
-
-                        const { possibleRulings, state, finalRuling } = await courtHelper.getDispute(disputeId)
-
-                        const expectedDisputeState = (roundId < courtHelper.maxRegularAppealRounds.toNumber() - 1) ? DISPUTE_STATES.PRE_DRAFT : DISPUTE_STATES.ADJUDICATING
-                        assert.equal(state.toString(), expectedDisputeState.toString(), 'dispute state does not match')
-                        assert.equal(possibleRulings.toString(), 2, 'dispute possible rulings do not match')
-                        assert.equal(finalRuling.toString(), 0, 'dispute final ruling does not match')
-                      })
-
-                      it('cannot be confirmed twice', async () => {
-                        await court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker })
-
-                        await assertRevert(court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker }), 'CT_INVALID_ADJUDICATION_STATE')
-                      })
-                    }
-
-                    context('when the next round is a regular round', () => {
-                      itCreatesNewRoundSuccessfully(roundId)
-                    })
-
-                    context('when the next round is a final round', () => {
-                      const finalRoundId = DEFAULTS.maxRegularAppealRounds.toNumber()
-
-                      beforeEach('move to final round', async () => {
-                        // appeal until we reach the final round, always flipping the previous round winning ruling
-                        for (let nextRoundId = roundId + 1; nextRoundId < finalRoundId; nextRoundId++) {
-                          await courtHelper.confirmAppeal({ disputeId, roundId: nextRoundId - 1, appealTaker, ruling: appealTakerRuling })
-                          const roundVoters = await courtHelper.draft({ disputeId })
-                          roundVoters.forEach(voter => voter.outcome = appealTakerRuling)
-                          await courtHelper.commit({ disputeId, roundId: nextRoundId, voters: roundVoters })
-                          await courtHelper.reveal({ disputeId, roundId: nextRoundId, voters: roundVoters })
-                          await courtHelper.appeal({ disputeId, roundId: nextRoundId, appealMaker, ruling: appealMakerRuling })
-                        }
-
-                        // mint fee tokens for last appeal taker
-                        const { confirmAppealDeposit } = await courtHelper.getAppealFees(disputeId, finalRoundId - 1)
-                        await courtHelper.mintAndApproveFeeTokens(appealTaker, court.address, confirmAppealDeposit)
-                      })
-
-                      itCreatesNewRoundSuccessfully(finalRoundId - 1)
-                    })
-                  })
-
-                  context('when the appeal taker does not have enough balance', () => {
-                    it('reverts', async () => {
-                      await assertRevert(court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker }), 'CT_DEPOSIT_FAILED')
-                    })
-                  })
-                })
-
-                context('when the confirmed ruling is equal to the appealed one', () => {
-                  beforeEach('set confirmed ruling', async () => {
-                    appealTakerRuling = appealMakerRuling
-                  })
-
-                  it('reverts', async () => {
-                    await assertRevert(court.confirmAppeal(disputeId, roundId, appealMakerRuling, { from: appealTaker }), 'CT_INVALID_APPEAL_RULING')
-                  })
-                })
-              })
-
-              context('when the confirmed ruling is not valid', () => {
-                const invalidRuling = 10
-
-                it('reverts', async () => {
-                  await assertRevert(court.confirmAppeal(disputeId, roundId, invalidRuling, { from: appealTaker }), 'CT_INVALID_APPEAL_RULING')
-                })
-              })
-            })
-          })
-
-          context('after the appeal confirmation period', () => {
-            beforeEach('commit and reveal votes', async () => {
-              await courtHelper.commit({ disputeId, roundId, voters })
-              await courtHelper.reveal({ disputeId, roundId, voters })
-            })
-
-            context('when the round was not appealed', () => {
-              beforeEach('pass appeal and confirmation periods', async () => {
-                await courtHelper.passTerms(courtHelper.appealTerms.add(courtHelper.appealConfirmTerms))
-              })
-
-              itIsAtState(roundId, ROUND_STATES.ENDED)
-              itFailsToConfirmAppeal(roundId)
-            })
-
-            context('when the round was appealed', () => {
-              beforeEach('appeal', async () => {
-                await courtHelper.appeal({ disputeId, roundId, appealMaker })
-              })
-
-              context('when the appeal was not confirmed', () => {
-                beforeEach('pass confirmation period', async () => {
-                  await courtHelper.passTerms(courtHelper.appealConfirmTerms)
-                })
-
-                itIsAtState(roundId, ROUND_STATES.ENDED)
-                itFailsToConfirmAppeal(roundId)
-              })
-
-              context('when the appeal was confirmed', () => {
-                beforeEach('confirm appeal', async () => {
-                  await courtHelper.confirmAppeal({ disputeId, roundId, appealTaker })
-                })
-
-                itIsAtState(roundId, ROUND_STATES.ENDED)
-                itFailsToConfirmAppeal(roundId)
-              })
-            })
-          })
+  context('when the given dispute exists', () => {
+    let disputeId
+    const draftTermId = 4
+
+    beforeEach('activate jurors and create dispute', async () => {
+      await courtHelper.activate(jurors)
+
+      await courtHelper.setTerm(1)
+      disputeId = await courtHelper.dispute({ draftTermId, disputer })
+      await courtHelper.passTerms(bn(draftTermId - 1)) // court is already at term one
+    })
+
+    context('when the given round is valid', () => {
+      let voteId, voters, nonVoters
+
+      const itIsAtState = (roundId, state) => {
+        it(`round is at state ${state}`, async () => {
+          const { roundState } = await courtHelper.getRound(disputeId, roundId)
+          assert.equal(roundState.toString(), state.toString(), 'round state does not match')
+        })
+      }
+
+      const itFailsToConfirmAppeal = (roundId, reason = 'CT_INVALID_ADJUDICATION_STATE') => {
+        it('fails to confirm appeals', async () => {
+          await assertRevert(court.confirmAppeal(disputeId, roundId, OUTCOMES.REFUSED), reason)
+        })
+      }
+
+      context('for a regular round', () => {
+        const roundId = 0
+        let draftedJurors, nonDraftedJurors
+
+        beforeEach('draft round', async () => {
+          draftedJurors = await courtHelper.draft({ disputeId, drafter })
+          nonDraftedJurors = jurors.filter(juror => !draftedJurors.map(j => j.address).includes(juror.address))
         })
 
-        context('for a final round', () => {
-          const roundId = DEFAULTS.maxRegularAppealRounds.toNumber()
+        beforeEach('define a group of voters', async () => {
+          voteId = getVoteId(disputeId, roundId)
+          // pick the first 3 drafted jurors to vote
+          voters = draftedJurors.slice(0, 3)
+          voters.forEach((voter, i) => voter.outcome = outcomeFor(i))
+          nonVoters = filterJurors(draftedJurors, voters)
+        })
 
-          beforeEach('move to final round', async () => {
-            await courtHelper.moveToFinalRound({ disputeId })
+        context('during commit period', () => {
+          itIsAtState(roundId, ROUND_STATES.COMMITTING)
+          itFailsToConfirmAppeal(roundId)
+        })
+
+        context('during reveal period', () => {
+          beforeEach('commit votes', async () => {
+            await courtHelper.commit({ disputeId, roundId, voters })
           })
 
-          beforeEach('define a group of voters', async () => {
-            voteId = getVoteId(disputeId, roundId)
-            voters = [
-              { address: juror1000, outcome: OUTCOMES.LOW },
-              { address: juror4000, outcome: OUTCOMES.LOW },
-              { address: juror2000, outcome: OUTCOMES.HIGH },
-              { address: juror1500, outcome: OUTCOMES.REFUSED },
-            ]
-            nonVoters = filterJurors(jurors, voters)
+          itIsAtState(roundId, ROUND_STATES.REVEALING)
+          itFailsToConfirmAppeal(roundId)
+        })
+
+        context('during appeal period', () => {
+          beforeEach('commit and reveal votes', async () => {
+            await courtHelper.commit({ disputeId, roundId, voters })
+            await courtHelper.reveal({ disputeId, roundId, voters })
           })
 
-          const itCannotComputeNextRoundDetails = () => {
-            it('cannot compute next round details', async () => {
-              await assertRevert(court.getNextRoundDetails(disputeId, roundId), 'CT_ROUND_IS_FINAL')
-            })
-          }
+          itIsAtState(roundId, ROUND_STATES.APPEALING)
+          itFailsToConfirmAppeal(roundId)
+        })
 
-          context('during commit period', () => {
-            itIsAtState(roundId, ROUND_STATES.COMMITTING)
-            itFailsToConfirmAppeal(roundId)
-            itCannotComputeNextRoundDetails()
+        context('during the appeal confirmation period', () => {
+          beforeEach('commit and reveal votes', async () => {
+            await courtHelper.commit({ disputeId, roundId, voters })
+            await courtHelper.reveal({ disputeId, roundId, voters })
           })
 
-          context('during reveal period', () => {
-            beforeEach('commit votes', async () => {
-              await courtHelper.commit({ disputeId, roundId, voters })
-            })
-
-            itIsAtState(roundId, ROUND_STATES.REVEALING)
-            itFailsToConfirmAppeal(roundId)
-            itCannotComputeNextRoundDetails()
-          })
-
-          context('during appeal period', () => {
-            beforeEach('commit and reveal votes', async () => {
-              await courtHelper.commit({ disputeId, roundId, voters })
-              await courtHelper.reveal({ disputeId, roundId, voters })
-            })
-
-            itIsAtState(roundId, ROUND_STATES.ENDED)
-            itFailsToConfirmAppeal(roundId)
-            itCannotComputeNextRoundDetails()
-          })
-
-          context('during the appeal confirmation period', () => {
-            beforeEach('commit and reveal votes, and pass appeal period', async () => {
-              await courtHelper.commit({ disputeId, roundId, voters })
-              await courtHelper.reveal({ disputeId, roundId, voters })
+          context('when the round was not appealed', () => {
+            beforeEach('pass appeal period', async () => {
               await courtHelper.passTerms(courtHelper.appealTerms)
             })
 
             itIsAtState(roundId, ROUND_STATES.ENDED)
             itFailsToConfirmAppeal(roundId)
-            itCannotComputeNextRoundDetails()
           })
 
-          context('after the appeal confirmation period', () => {
-            beforeEach('commit and reveal votes, and pass appeal and confirmation periods', async () => {
-              await courtHelper.commit({ disputeId, roundId, voters })
-              await courtHelper.reveal({ disputeId, roundId, voters })
+          context('when the round was appealed', () => {
+            let appealMakerRuling
+
+            beforeEach('appeal and move to appeal confirmation period', async () => {
+              await courtHelper.appeal({ disputeId, roundId, appealMaker })
+              const { appealedRuling } = await courtHelper.getAppeal(disputeId, roundId)
+              appealMakerRuling = appealedRuling
+            })
+
+            context('when the confirmed ruling is valid', () => {
+              let appealTakerRuling
+
+              context('when the confirmed ruling is different from the appealed one', () => {
+                beforeEach('set confirmed ruling', async () => {
+                  appealTakerRuling = oppositeOutcome(appealMakerRuling)
+                })
+
+                context('when the appeal taker has enough balance', () => {
+                  beforeEach('mint fee tokens for appeal taker', async () => {
+                    const { confirmAppealDeposit } = await courtHelper.getAppealFees(disputeId, roundId)
+                    await courtHelper.mintAndApproveFeeTokens(appealTaker, court.address, confirmAppealDeposit)
+                  })
+
+                  const itCreatesNewRoundSuccessfully = roundId => {
+                    it('computes next round details successfully', async () => {
+                      const { nextRoundStartTerm, nextRoundJurorsNumber, newDisputeState, feeToken, totalFees, jurorFees, appealDeposit, confirmAppealDeposit } = await court.getNextRoundDetails(disputeId, roundId)
+
+                      const expectedStartTerm = await courtHelper.getNextRoundStartTerm(disputeId, roundId)
+                      assert.equal(nextRoundStartTerm.toString(), expectedStartTerm.toString(), 'next round start term does not match')
+
+                      const expectedJurorsNumber = await courtHelper.getNextRoundJurorsNumber(disputeId, roundId)
+                      assert.equal(nextRoundJurorsNumber.toString(), expectedJurorsNumber.toString(), 'next round jurors number does not match')
+
+                      const expectedDisputeState = (roundId < courtHelper.maxRegularAppealRounds.toNumber() - 1) ? DISPUTE_STATES.PRE_DRAFT : DISPUTE_STATES.ADJUDICATING
+                      assert.equal(newDisputeState.toString(), expectedDisputeState.toString(), 'next round jurors number does not match')
+
+                      const expectedJurorFees = await courtHelper.getNextRoundJurorFees(disputeId, roundId)
+                      assert.equal(jurorFees.toString(), expectedJurorFees.toString(), 'juror fees does not match')
+
+                      const { appealFees, appealDeposit: expectedAppealDeposit, confirmAppealDeposit: expectedConfirmAppealDeposit } = await courtHelper.getAppealFees(disputeId, roundId)
+                      assert.equal(feeToken, courtHelper.feeToken.address, 'fee token does not match')
+                      assert.equal(totalFees.toString(), appealFees.toString(), 'appeal fees does not match')
+                      assert.equal(appealDeposit.toString(), expectedAppealDeposit.toString(), 'appeal deposit does not match')
+                      assert.equal(confirmAppealDeposit.toString(), expectedConfirmAppealDeposit.toString(), 'confirm appeal deposit does not match')
+                    })
+
+                    it('computes final jurors number nevertheless the court current term', async () => {
+                      const previousTermId = await court.getCurrentTermId()
+                      const previousActiveBalance = await courtHelper.jurorsRegistry.totalActiveBalanceAt(previousTermId)
+                      const previousJurorsNumber = await courtHelper.getNextRoundJurorsNumber(disputeId, roundId)
+
+                      await courtHelper.passTerms(bn(1))
+                      await courtHelper.activate(jurors)
+                      await courtHelper.passTerms(bn(1))
+
+                      const currentTermId = await court.getCurrentTermId()
+                      const currentActiveBalance = await courtHelper.jurorsRegistry.totalActiveBalanceAt(currentTermId)
+                      assert.equal(currentActiveBalance.toString(), previousActiveBalance.mul(bn(2)).toString(), 'new total active balance does not match')
+
+                      const currentJurorsNumber = await courtHelper.getNextRoundJurorsNumber(disputeId, roundId)
+                      assert.equal(previousJurorsNumber.toString(), currentJurorsNumber.toString(), 'next round jurors number does not match')
+                    })
+
+                    it('emits an event', async () => {
+                      const receipt = await court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker })
+
+                      assertAmountOfEvents(receipt, 'RulingAppealConfirmed')
+
+                      const nextRoundStartTerm = await courtHelper.getNextRoundStartTerm(disputeId, roundId)
+                      const nextRoundJurorsNumber = await courtHelper.getNextRoundJurorsNumber(disputeId, roundId)
+                      assertEvent(receipt, 'RulingAppealConfirmed', {
+                        disputeId,
+                        roundId: roundId + 1,
+                        draftTermId: nextRoundStartTerm,
+                        jurorsNumber: nextRoundJurorsNumber
+                      })
+                    })
+
+                    it('confirms the given appealed round', async () => {
+                      await court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker })
+
+                      const { appealer, appealedRuling, taker, opposedRuling } = await courtHelper.getAppeal(disputeId, roundId)
+                      assert.equal(appealer, appealMaker, 'appeal maker does not match')
+                      assert.equal(appealedRuling.toString(), appealMakerRuling, 'appealed ruling does not match')
+                      assert.equal(taker.toString(), appealTaker, 'appeal taker does not match')
+                      assert.equal(opposedRuling.toString(), appealTakerRuling, 'opposed ruling does not match')
+                    })
+
+                    it('creates a new round for the given dispute', async () => {
+                      await court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker })
+
+                      const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, triggeredBy, settledPenalties, jurorFees, collectedTokens } = await courtHelper.getRound(disputeId, roundId + 1)
+
+                      const nextRoundStartTerm = await courtHelper.getNextRoundStartTerm(disputeId, roundId)
+                      assert.equal(draftTerm.toString(), nextRoundStartTerm.toString(), 'new round draft term does not match')
+                      assert.equal(delayedTerms.toString(), 0, 'new round delay term does not match')
+
+                      const nextRoundJurorsNumber = await courtHelper.getNextRoundJurorsNumber(disputeId, roundId)
+                      assert.equal(roundJurorsNumber.toString(), nextRoundJurorsNumber.toString(), 'new round jurors number does not match')
+
+                      const nextRoundJurorFees = await courtHelper.getNextRoundJurorFees(disputeId, roundId)
+                      assert.equal(jurorFees.toString(), nextRoundJurorFees.toString(), 'new round juror fees do not match')
+
+                      assert.equal(selectedJurors.toString(), 0, 'new round selected jurors number does not match')
+                      assert.equal(triggeredBy, appealTaker, 'new round trigger does not match')
+                      assert.equal(settledPenalties, false, 'new round penalties should not be settled')
+                      assert.equal(collectedTokens.toString(), 0, 'new round collected tokens should be zero')
+                    })
+
+                    it('does not modify the current round of the dispute', async () => {
+                      const { draftTerm: previousDraftTerm, delayedTerms: previousDelayedTerms, roundJurorsNumber: previousJurorsNumber, jurorFees: previousJurorFees, triggeredBy: previousTriggeredBy } = await courtHelper.getRound(disputeId, roundId)
+
+                      await court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker })
+
+                      const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, jurorFees, triggeredBy, settledPenalties, collectedTokens } = await courtHelper.getRound(disputeId, roundId)
+                      assert.equal(draftTerm.toString(), previousDraftTerm.toString(), 'current round draft term does not match')
+                      assert.equal(delayedTerms.toString(), previousDelayedTerms.toString(), 'current round delay term does not match')
+                      assert.equal(roundJurorsNumber.toString(), previousJurorsNumber.toString(), 'current round jurors number does not match')
+                      assert.equal(selectedJurors.toString(), previousJurorsNumber.toString(), 'current round selected jurors number does not match')
+                      assert.equal(jurorFees.toString(), previousJurorFees.toString(), 'current round juror fees do not match')
+                      assert.equal(triggeredBy, previousTriggeredBy, 'current round trigger does not match')
+                      assert.equal(settledPenalties, false, 'current round penalties should not be settled')
+                      assert.equal(collectedTokens.toString(), 0, 'current round collected tokens should be zero')
+                    })
+
+                    it('updates the dispute state', async () => {
+                      await court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker })
+
+                      const { possibleRulings, state, finalRuling } = await courtHelper.getDispute(disputeId)
+
+                      const expectedDisputeState = (roundId < courtHelper.maxRegularAppealRounds.toNumber() - 1) ? DISPUTE_STATES.PRE_DRAFT : DISPUTE_STATES.ADJUDICATING
+                      assert.equal(state.toString(), expectedDisputeState.toString(), 'dispute state does not match')
+                      assert.equal(possibleRulings.toString(), 2, 'dispute possible rulings do not match')
+                      assert.equal(finalRuling.toString(), 0, 'dispute final ruling does not match')
+                    })
+
+                    it('cannot be confirmed twice', async () => {
+                      await court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker })
+
+                      await assertRevert(court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker }), 'CT_INVALID_ADJUDICATION_STATE')
+                    })
+                  }
+
+                  context('when the next round is a regular round', () => {
+                    itCreatesNewRoundSuccessfully(roundId)
+                  })
+
+                  context('when the next round is a final round', () => {
+                    const finalRoundId = DEFAULTS.maxRegularAppealRounds.toNumber()
+
+                    beforeEach('move to final round', async () => {
+                      // appeal until we reach the final round, always flipping the previous round winning ruling
+                      for (let nextRoundId = roundId + 1; nextRoundId < finalRoundId; nextRoundId++) {
+                        await courtHelper.confirmAppeal({ disputeId, roundId: nextRoundId - 1, appealTaker, ruling: appealTakerRuling })
+                        const roundVoters = await courtHelper.draft({ disputeId })
+                        roundVoters.forEach(voter => voter.outcome = appealTakerRuling)
+                        await courtHelper.commit({ disputeId, roundId: nextRoundId, voters: roundVoters })
+                        await courtHelper.reveal({ disputeId, roundId: nextRoundId, voters: roundVoters })
+                        await courtHelper.appeal({ disputeId, roundId: nextRoundId, appealMaker, ruling: appealMakerRuling })
+                      }
+
+                      // mint fee tokens for last appeal taker
+                      const { confirmAppealDeposit } = await courtHelper.getAppealFees(disputeId, finalRoundId - 1)
+                      await courtHelper.mintAndApproveFeeTokens(appealTaker, court.address, confirmAppealDeposit)
+                    })
+
+                    itCreatesNewRoundSuccessfully(finalRoundId - 1)
+                  })
+                })
+
+                context('when the appeal taker does not have enough balance', () => {
+                  it('reverts', async () => {
+                    await assertRevert(court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker }), 'CT_DEPOSIT_FAILED')
+                  })
+                })
+              })
+
+              context('when the confirmed ruling is equal to the appealed one', () => {
+                beforeEach('set confirmed ruling', async () => {
+                  appealTakerRuling = appealMakerRuling
+                })
+
+                it('reverts', async () => {
+                  await assertRevert(court.confirmAppeal(disputeId, roundId, appealMakerRuling, { from: appealTaker }), 'CT_INVALID_APPEAL_RULING')
+                })
+              })
+            })
+
+            context('when the confirmed ruling is not valid', () => {
+              const invalidRuling = 10
+
+              it('reverts', async () => {
+                await assertRevert(court.confirmAppeal(disputeId, roundId, invalidRuling, { from: appealTaker }), 'CT_INVALID_APPEAL_RULING')
+              })
+            })
+          })
+        })
+
+        context('after the appeal confirmation period', () => {
+          beforeEach('commit and reveal votes', async () => {
+            await courtHelper.commit({ disputeId, roundId, voters })
+            await courtHelper.reveal({ disputeId, roundId, voters })
+          })
+
+          context('when the round was not appealed', () => {
+            beforeEach('pass appeal and confirmation periods', async () => {
               await courtHelper.passTerms(courtHelper.appealTerms.add(courtHelper.appealConfirmTerms))
             })
 
             itIsAtState(roundId, ROUND_STATES.ENDED)
             itFailsToConfirmAppeal(roundId)
-            itCannotComputeNextRoundDetails()
+          })
+
+          context('when the round was appealed', () => {
+            beforeEach('appeal', async () => {
+              await courtHelper.appeal({ disputeId, roundId, appealMaker })
+            })
+
+            context('when the appeal was not confirmed', () => {
+              beforeEach('pass confirmation period', async () => {
+                await courtHelper.passTerms(courtHelper.appealConfirmTerms)
+              })
+
+              itIsAtState(roundId, ROUND_STATES.ENDED)
+              itFailsToConfirmAppeal(roundId)
+            })
+
+            context('when the appeal was confirmed', () => {
+              beforeEach('confirm appeal', async () => {
+                await courtHelper.confirmAppeal({ disputeId, roundId, appealTaker })
+              })
+
+              itIsAtState(roundId, ROUND_STATES.ENDED)
+              itFailsToConfirmAppeal(roundId)
+            })
           })
         })
       })
 
-      context('when the given round is not valid', () => {
-        const roundId = 5
+      context('for a final round', () => {
+        const roundId = DEFAULTS.maxRegularAppealRounds.toNumber()
 
-        it('reverts', async () => {
-          await assertRevert(court.confirmAppeal(disputeId, roundId, OUTCOMES.LOW), 'CT_ROUND_DOES_NOT_EXIST')
+        beforeEach('move to final round', async () => {
+          await courtHelper.moveToFinalRound({ disputeId })
+        })
+
+        beforeEach('define a group of voters', async () => {
+          voteId = getVoteId(disputeId, roundId)
+          voters = [
+            { address: juror1000, outcome: OUTCOMES.LOW },
+            { address: juror4000, outcome: OUTCOMES.LOW },
+            { address: juror2000, outcome: OUTCOMES.HIGH },
+            { address: juror1500, outcome: OUTCOMES.REFUSED },
+          ]
+          nonVoters = filterJurors(jurors, voters)
+        })
+
+        const itCannotComputeNextRoundDetails = () => {
+          it('cannot compute next round details', async () => {
+            await assertRevert(court.getNextRoundDetails(disputeId, roundId), 'CT_ROUND_IS_FINAL')
+          })
+        }
+
+        context('during commit period', () => {
+          itIsAtState(roundId, ROUND_STATES.COMMITTING)
+          itFailsToConfirmAppeal(roundId)
+          itCannotComputeNextRoundDetails()
+        })
+
+        context('during reveal period', () => {
+          beforeEach('commit votes', async () => {
+            await courtHelper.commit({ disputeId, roundId, voters })
+          })
+
+          itIsAtState(roundId, ROUND_STATES.REVEALING)
+          itFailsToConfirmAppeal(roundId)
+          itCannotComputeNextRoundDetails()
+        })
+
+        context('during appeal period', () => {
+          beforeEach('commit and reveal votes', async () => {
+            await courtHelper.commit({ disputeId, roundId, voters })
+            await courtHelper.reveal({ disputeId, roundId, voters })
+          })
+
+          itIsAtState(roundId, ROUND_STATES.ENDED)
+          itFailsToConfirmAppeal(roundId)
+          itCannotComputeNextRoundDetails()
+        })
+
+        context('during the appeal confirmation period', () => {
+          beforeEach('commit and reveal votes, and pass appeal period', async () => {
+            await courtHelper.commit({ disputeId, roundId, voters })
+            await courtHelper.reveal({ disputeId, roundId, voters })
+            await courtHelper.passTerms(courtHelper.appealTerms)
+          })
+
+          itIsAtState(roundId, ROUND_STATES.ENDED)
+          itFailsToConfirmAppeal(roundId)
+          itCannotComputeNextRoundDetails()
+        })
+
+        context('after the appeal confirmation period', () => {
+          beforeEach('commit and reveal votes, and pass appeal and confirmation periods', async () => {
+            await courtHelper.commit({ disputeId, roundId, voters })
+            await courtHelper.reveal({ disputeId, roundId, voters })
+            await courtHelper.passTerms(courtHelper.appealTerms.add(courtHelper.appealConfirmTerms))
+          })
+
+          itIsAtState(roundId, ROUND_STATES.ENDED)
+          itFailsToConfirmAppeal(roundId)
+          itCannotComputeNextRoundDetails()
         })
       })
     })
 
-    // TODO: this scenario is not implemented in the contracts yet
-    context.skip('when the given dispute does not exist', () => {
+    context('when the given round is not valid', () => {
+      const roundId = 5
+
       it('reverts', async () => {
-        await assertRevert(court.confirmAppeal(0, 0, OUTCOMES.LOW), 'CT_DISPUTE_DOES_NOT_EXIST')
+        await assertRevert(court.confirmAppeal(disputeId, roundId, OUTCOMES.LOW), 'CT_ROUND_DOES_NOT_EXIST')
       })
+    })
+  })
+
+  // TODO: this scenario is not implemented in the contracts yet
+  context.skip('when the given dispute does not exist', () => {
+    it('reverts', async () => {
+      await assertRevert(court.confirmAppeal(0, 0, OUTCOMES.LOW), 'CT_DISPUTE_DOES_NOT_EXIST')
     })
   })
 })

--- a/test/court/court-disputes.js
+++ b/test/court/court-disputes.js
@@ -9,7 +9,7 @@ const Arbitrable = artifacts.require('ArbitrableMock')
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
-contract('Court', ([_, sender]) => {
+contract('Court (disputes)', ([_, sender]) => {
   let courtHelper, court, feeToken, arbitrable
 
   const termDuration = bn(ONE_DAY)

--- a/test/court/court-draft.js
+++ b/test/court/court-draft.js
@@ -9,7 +9,7 @@ const { buildHelper, DISPUTE_STATES, ROUND_STATES } = require('../helpers/court'
 
 const JurorsRegistry = artifacts.require('JurorsRegistry')
 
-contract('Court', ([_, disputer, drafter, juror500, juror1000, juror1500, juror2000]) => {
+contract('Court (draft)', ([_, disputer, drafter, juror500, juror1000, juror1500, juror2000]) => {
   let courtHelper, court
 
   const jurors = [
@@ -25,153 +25,41 @@ contract('Court', ([_, disputer, drafter, juror500, juror1000, juror1500, juror2
     court = await courtHelper.deploy({ firstRoundJurorsNumber })
   })
 
-  describe('draft', () => {
-    context('when the given dispute exists', () => {
-      let disputeId
+  context('when the given dispute exists', () => {
+    let disputeId
 
-      const roundId = 0
-      const draftTermId = 4
+    const roundId = 0
+    const draftTermId = 4
 
-      beforeEach('create dispute', async () => {
-        await courtHelper.activate(jurors)
-        await courtHelper.setTerm(1)
-        disputeId = await courtHelper.dispute({ draftTermId, disputer })
+    beforeEach('create dispute', async () => {
+      await courtHelper.activate(jurors)
+      await courtHelper.setTerm(1)
+      disputeId = await courtHelper.dispute({ draftTermId, disputer })
+    })
+
+    const itDraftsRequestedRoundInOneBatch = (term, jurorsToBeDrafted) => {
+      const expectedDraftedJurors = jurorsToBeDrafted > firstRoundJurorsNumber ? firstRoundJurorsNumber : jurorsToBeDrafted
+
+      it('selects random jurors for the last round of the dispute', async () => {
+        const receipt = await court.draft(disputeId, jurorsToBeDrafted, { from: drafter })
+
+        const logs = decodeEventsOfType(receipt, JurorsRegistry.abi, 'JurorDrafted')
+        assertAmountOfEvents({ logs }, 'JurorDrafted', expectedDraftedJurors)
+
+        const jurorsAddresses = jurors.map(j => j.address)
+        for(let i = 0; i < expectedDraftedJurors; i++) {
+          const { disputeId: eventDisputeId, juror } = getEventAt({ logs }, 'JurorDrafted', i).args
+          assert.equal(eventDisputeId.toString(), disputeId, 'dispute id does not match')
+          assert.isTrue(jurorsAddresses.includes(toChecksumAddress(juror)), 'drafted juror is not included in the list')
+        }
       })
 
-      const itDraftsRequestedRoundInOneBatch = (term, jurorsToBeDrafted) => {
-        const expectedDraftedJurors = jurorsToBeDrafted > firstRoundJurorsNumber ? firstRoundJurorsNumber : jurorsToBeDrafted
-
-        it('selects random jurors for the last round of the dispute', async () => {
-          const receipt = await court.draft(disputeId, jurorsToBeDrafted, { from: drafter })
-
-          const logs = decodeEventsOfType(receipt, JurorsRegistry.abi, 'JurorDrafted')
-          assertAmountOfEvents({ logs }, 'JurorDrafted', expectedDraftedJurors)
-
-          const jurorsAddresses = jurors.map(j => j.address)
-          for(let i = 0; i < expectedDraftedJurors; i++) {
-            const { disputeId: eventDisputeId, juror } = getEventAt({ logs }, 'JurorDrafted', i).args
-            assert.equal(eventDisputeId.toString(), disputeId, 'dispute id does not match')
-            assert.isTrue(jurorsAddresses.includes(toChecksumAddress(juror)), 'drafted juror is not included in the list')
-          }
-        })
-
-        if (expectedDraftedJurors === firstRoundJurorsNumber) {
-          it('ends the dispute draft', async () => {
-            const receipt = await court.draft(disputeId, jurorsToBeDrafted, { from: drafter })
-
-            assertAmountOfEvents(receipt, 'DisputeStateChanged')
-            assertEvent(receipt, 'DisputeStateChanged', { disputeId, state: DISPUTE_STATES.ADJUDICATING })
-
-            const { state, finalRuling } = await courtHelper.getDispute(disputeId)
-            assert.equal(state.toString(), DISPUTE_STATES.ADJUDICATING.toString(), 'dispute state does not match')
-            assert.equal(finalRuling.toString(), 0, 'dispute final ruling does not match')
-          })
-
-          it('updates last round information', async () => {
-            await court.draft(disputeId, jurorsToBeDrafted, { from: drafter })
-
-            const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, jurorFees, roundState } = await courtHelper.getRound(disputeId, roundId)
-            assert.equal(draftTerm.toString(), draftTermId, 'round draft term does not match')
-            assert.equal(delayedTerms.toString(), term - draftTermId, 'delayed terms do not match')
-            assert.equal(roundJurorsNumber.toString(), firstRoundJurorsNumber, 'round jurors number does not match')
-            assert.equal(selectedJurors.toString(), firstRoundJurorsNumber, 'selected jurors does not match')
-            assert.equal(jurorFees.toString(), courtHelper.jurorFee.mul(bn(firstRoundJurorsNumber)).toString(), 'round juror fees do not match')
-            assert.equal(roundState.toString(), ROUND_STATES.COMMITTING.toString(), 'round state should be committing')
-          })
-        } else {
-          it('does not end the dispute draft', async () => {
-            const receipt = await court.draft(disputeId, jurorsToBeDrafted, { from: drafter })
-
-            assertAmountOfEvents(receipt, 'DisputeStateChanged', 0)
-
-            const { state, finalRuling } = await courtHelper.getDispute(disputeId)
-            assert.equal(state.toString(), DISPUTE_STATES.PRE_DRAFT.toString(), 'dispute state does not match')
-            assert.equal(finalRuling.toString(), 0, 'dispute final ruling does not match')
-          })
-
-          it('updates last round information', async () => {
-            await court.draft(disputeId, jurorsToBeDrafted, { from: drafter })
-
-            const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, jurorFees, roundState } = await courtHelper.getRound(disputeId, roundId)
-            assert.equal(draftTerm.toString(), draftTermId, 'round draft term does not match')
-            assert.equal(delayedTerms.toString(), 0, 'delayed terms do not match')
-            assert.equal(roundJurorsNumber.toString(), firstRoundJurorsNumber, 'round jurors number does not match')
-            assert.equal(selectedJurors.toString(), expectedDraftedJurors, 'selected jurors does not match')
-            assert.equal(jurorFees.toString(), courtHelper.jurorFee.mul(bn(firstRoundJurorsNumber)).toString(), 'round juror fees do not match')
-            assert.equal(roundState.toString(), ROUND_STATES.INVALID.toString(), 'round state should be committing')
-          })
-        }
-
-        it('sets the correct state for each juror', async () => {
-          const receipt = await court.draft(disputeId, jurorsToBeDrafted, { from: drafter })
-
-          const logs = decodeEventsOfType(receipt, JurorsRegistry.abi, 'JurorDrafted')
-          const events = getEvents({ logs }, 'JurorDrafted')
-
-          for(let i = 0; i < jurors.length; i++) {
-            const jurorAddress = jurors[i].address
-            const expectedWeight = events.filter(({ args: { juror } }) => toChecksumAddress(juror) === jurorAddress).length
-            const { weight, rewarded } = await courtHelper.getRoundJuror(disputeId, roundId, jurorAddress)
-
-            assert.equal(weight.toString(), expectedWeight, 'juror weight does not match')
-            assert.isFalse(rewarded, 'juror should not have been rewarded yet')
-          }
-        })
-
-        it('deposits the draft fee to the accounting for the caller', async () => {
-          const { draftFee, accounting, feeToken } = courtHelper
-          const expectedFee = draftFee.mul(bn(expectedDraftedJurors))
-
-          const previousCourtAmount = await feeToken.balanceOf(court.address)
-          const previousAccountingAmount = await feeToken.balanceOf(accounting.address)
-          const previousDrafterAmount = await accounting.balanceOf(feeToken.address, drafter)
-
-          await court.draft(disputeId, jurorsToBeDrafted, { from: drafter })
-
-          const currentCourtAmount = await feeToken.balanceOf(court.address)
-          assert.equal(previousCourtAmount.toString(), currentCourtAmount.toString(), 'court balances should remain the same')
-
-          const currentAccountingAmount = await feeToken.balanceOf(accounting.address)
-          assert.equal(previousAccountingAmount.toString(), currentAccountingAmount.toString(), 'accounting balances should remain the same')
-
-          const currentDrafterAmount = await accounting.balanceOf(feeToken.address, drafter)
-          assert.equal(previousDrafterAmount.add(expectedFee).toString(), currentDrafterAmount.toString(), 'drafter amount does not match')
-        })
-      }
-
-      const itDraftsRequestedRoundInMultipleBatches = (term, jurorsToBeDrafted, batches, jurorsPerBatch) => {
-        it('selects random jurors for the last round of the dispute', async () => {
-          const jurorsAddresses = jurors.map(j => j.address)
-
-          for (let batch = 0, selectedJurors = 0; batch < batches; batch++, selectedJurors += jurorsPerBatch) {
-            // advance one term to avoid drafting all the batches in the same term
-            await courtHelper.passRealTerms(1)
-            const receipt = await court.draft(disputeId, jurorsPerBatch, { from: drafter })
-
-            const pendingJurorsToBeDrafted = jurorsToBeDrafted - selectedJurors
-            const expectedDraftedJurors = pendingJurorsToBeDrafted < jurorsPerBatch ? pendingJurorsToBeDrafted : jurorsPerBatch
-
-            const logs = decodeEventsOfType(receipt, JurorsRegistry.abi, 'JurorDrafted')
-            assertAmountOfEvents({ logs }, 'JurorDrafted', expectedDraftedJurors)
-
-            for(let i = 0; i < expectedDraftedJurors; i++) {
-              const { disputeId: eventDisputeId, juror } = getEventAt({ logs }, 'JurorDrafted', i).args
-              assert.equal(eventDisputeId.toString(), disputeId, 'dispute id does not match')
-              assert.isTrue(jurorsAddresses.includes(toChecksumAddress(juror)), 'drafted juror is not included in the list')
-            }
-          }
-        })
-
+      if (expectedDraftedJurors === firstRoundJurorsNumber) {
         it('ends the dispute draft', async () => {
-          let lastReceipt
-          for (let batch = 0; batch < batches; batch++) {
-            // advance one term to avoid drafting all the batches in the same term
-            await courtHelper.passRealTerms(1)
-            lastReceipt = await court.draft(disputeId, jurorsPerBatch, { from: drafter })
-          }
+          const receipt = await court.draft(disputeId, jurorsToBeDrafted, { from: drafter })
 
-          assertAmountOfEvents(lastReceipt, 'DisputeStateChanged')
-          assertEvent(lastReceipt, 'DisputeStateChanged', { disputeId, state: DISPUTE_STATES.ADJUDICATING })
+          assertAmountOfEvents(receipt, 'DisputeStateChanged')
+          assertEvent(receipt, 'DisputeStateChanged', { disputeId, state: DISPUTE_STATES.ADJUDICATING })
 
           const { state, finalRuling } = await courtHelper.getDispute(disputeId)
           assert.equal(state.toString(), DISPUTE_STATES.ADJUDICATING.toString(), 'dispute state does not match')
@@ -179,252 +67,362 @@ contract('Court', ([_, disputer, drafter, juror500, juror1000, juror1500, juror2
         })
 
         it('updates last round information', async () => {
-          let lastTerm
-          for (let batch = 0; batch < batches; batch++) {
-            // advance one term to avoid drafting all the batches in the same term
-            await courtHelper.passRealTerms(1)
-            await court.draft(disputeId, jurorsPerBatch, { from: drafter })
-            lastTerm = await court.getLastEnsuredTermId()
-          }
+          await court.draft(disputeId, jurorsToBeDrafted, { from: drafter })
 
           const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, jurorFees, roundState } = await courtHelper.getRound(disputeId, roundId)
-
           assert.equal(draftTerm.toString(), draftTermId, 'round draft term does not match')
-          assert.equal(delayedTerms.toString(), lastTerm - draftTermId, 'delayed terms do not match')
+          assert.equal(delayedTerms.toString(), term - draftTermId, 'delayed terms do not match')
           assert.equal(roundJurorsNumber.toString(), firstRoundJurorsNumber, 'round jurors number does not match')
           assert.equal(selectedJurors.toString(), firstRoundJurorsNumber, 'selected jurors does not match')
           assert.equal(jurorFees.toString(), courtHelper.jurorFee.mul(bn(firstRoundJurorsNumber)).toString(), 'round juror fees do not match')
           assert.equal(roundState.toString(), ROUND_STATES.COMMITTING.toString(), 'round state should be committing')
         })
+      } else {
+        it('does not end the dispute draft', async () => {
+          const receipt = await court.draft(disputeId, jurorsToBeDrafted, { from: drafter })
 
-        it('sets the correct state for each juror', async () => {
-          const expectedWeights = {}
+          assertAmountOfEvents(receipt, 'DisputeStateChanged', 0)
 
-          for (let batch = 0; batch < batches; batch++) {
-            // advance one term to avoid drafting all the batches in the same term
-            await courtHelper.passRealTerms(1)
-            const receipt = await court.draft(disputeId, jurorsPerBatch, { from: drafter })
+          const { state, finalRuling } = await courtHelper.getDispute(disputeId)
+          assert.equal(state.toString(), DISPUTE_STATES.PRE_DRAFT.toString(), 'dispute state does not match')
+          assert.equal(finalRuling.toString(), 0, 'dispute final ruling does not match')
+        })
 
-            const logs = decodeEventsOfType(receipt, JurorsRegistry.abi, 'JurorDrafted')
-            const events = getEvents({ logs }, 'JurorDrafted')
+        it('updates last round information', async () => {
+          await court.draft(disputeId, jurorsToBeDrafted, { from: drafter })
 
-            for(let i = 0; i < jurors.length; i++) {
-              const jurorAddress = jurors[i].address
-              const batchWeight = events.filter(({ args: { juror } }) => toChecksumAddress(juror) === jurorAddress).length
-              expectedWeights[jurorAddress] = (expectedWeights[jurorAddress] || 0) + batchWeight
-            }
+          const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, jurorFees, roundState } = await courtHelper.getRound(disputeId, roundId)
+          assert.equal(draftTerm.toString(), draftTermId, 'round draft term does not match')
+          assert.equal(delayedTerms.toString(), 0, 'delayed terms do not match')
+          assert.equal(roundJurorsNumber.toString(), firstRoundJurorsNumber, 'round jurors number does not match')
+          assert.equal(selectedJurors.toString(), expectedDraftedJurors, 'selected jurors does not match')
+          assert.equal(jurorFees.toString(), courtHelper.jurorFee.mul(bn(firstRoundJurorsNumber)).toString(), 'round juror fees do not match')
+          assert.equal(roundState.toString(), ROUND_STATES.INVALID.toString(), 'round state should be committing')
+        })
+      }
+
+      it('sets the correct state for each juror', async () => {
+        const receipt = await court.draft(disputeId, jurorsToBeDrafted, { from: drafter })
+
+        const logs = decodeEventsOfType(receipt, JurorsRegistry.abi, 'JurorDrafted')
+        const events = getEvents({ logs }, 'JurorDrafted')
+
+        for(let i = 0; i < jurors.length; i++) {
+          const jurorAddress = jurors[i].address
+          const expectedWeight = events.filter(({ args: { juror } }) => toChecksumAddress(juror) === jurorAddress).length
+          const { weight, rewarded } = await courtHelper.getRoundJuror(disputeId, roundId, jurorAddress)
+
+          assert.equal(weight.toString(), expectedWeight, 'juror weight does not match')
+          assert.isFalse(rewarded, 'juror should not have been rewarded yet')
+        }
+      })
+
+      it('deposits the draft fee to the accounting for the caller', async () => {
+        const { draftFee, accounting, feeToken } = courtHelper
+        const expectedFee = draftFee.mul(bn(expectedDraftedJurors))
+
+        const previousCourtAmount = await feeToken.balanceOf(court.address)
+        const previousAccountingAmount = await feeToken.balanceOf(accounting.address)
+        const previousDrafterAmount = await accounting.balanceOf(feeToken.address, drafter)
+
+        await court.draft(disputeId, jurorsToBeDrafted, { from: drafter })
+
+        const currentCourtAmount = await feeToken.balanceOf(court.address)
+        assert.equal(previousCourtAmount.toString(), currentCourtAmount.toString(), 'court balances should remain the same')
+
+        const currentAccountingAmount = await feeToken.balanceOf(accounting.address)
+        assert.equal(previousAccountingAmount.toString(), currentAccountingAmount.toString(), 'accounting balances should remain the same')
+
+        const currentDrafterAmount = await accounting.balanceOf(feeToken.address, drafter)
+        assert.equal(previousDrafterAmount.add(expectedFee).toString(), currentDrafterAmount.toString(), 'drafter amount does not match')
+      })
+    }
+
+    const itDraftsRequestedRoundInMultipleBatches = (term, jurorsToBeDrafted, batches, jurorsPerBatch) => {
+      it('selects random jurors for the last round of the dispute', async () => {
+        const jurorsAddresses = jurors.map(j => j.address)
+
+        for (let batch = 0, selectedJurors = 0; batch < batches; batch++, selectedJurors += jurorsPerBatch) {
+          // advance one term to avoid drafting all the batches in the same term
+          await courtHelper.passRealTerms(1)
+          const receipt = await court.draft(disputeId, jurorsPerBatch, { from: drafter })
+
+          const pendingJurorsToBeDrafted = jurorsToBeDrafted - selectedJurors
+          const expectedDraftedJurors = pendingJurorsToBeDrafted < jurorsPerBatch ? pendingJurorsToBeDrafted : jurorsPerBatch
+
+          const logs = decodeEventsOfType(receipt, JurorsRegistry.abi, 'JurorDrafted')
+          assertAmountOfEvents({ logs }, 'JurorDrafted', expectedDraftedJurors)
+
+          for(let i = 0; i < expectedDraftedJurors; i++) {
+            const { disputeId: eventDisputeId, juror } = getEventAt({ logs }, 'JurorDrafted', i).args
+            assert.equal(eventDisputeId.toString(), disputeId, 'dispute id does not match')
+            assert.isTrue(jurorsAddresses.includes(toChecksumAddress(juror)), 'drafted juror is not included in the list')
           }
+        }
+      })
+
+      it('ends the dispute draft', async () => {
+        let lastReceipt
+        for (let batch = 0; batch < batches; batch++) {
+          // advance one term to avoid drafting all the batches in the same term
+          await courtHelper.passRealTerms(1)
+          lastReceipt = await court.draft(disputeId, jurorsPerBatch, { from: drafter })
+        }
+
+        assertAmountOfEvents(lastReceipt, 'DisputeStateChanged')
+        assertEvent(lastReceipt, 'DisputeStateChanged', { disputeId, state: DISPUTE_STATES.ADJUDICATING })
+
+        const { state, finalRuling } = await courtHelper.getDispute(disputeId)
+        assert.equal(state.toString(), DISPUTE_STATES.ADJUDICATING.toString(), 'dispute state does not match')
+        assert.equal(finalRuling.toString(), 0, 'dispute final ruling does not match')
+      })
+
+      it('updates last round information', async () => {
+        let lastTerm
+        for (let batch = 0; batch < batches; batch++) {
+          // advance one term to avoid drafting all the batches in the same term
+          await courtHelper.passRealTerms(1)
+          await court.draft(disputeId, jurorsPerBatch, { from: drafter })
+          lastTerm = await court.getLastEnsuredTermId()
+        }
+
+        const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, jurorFees, roundState } = await courtHelper.getRound(disputeId, roundId)
+
+        assert.equal(draftTerm.toString(), draftTermId, 'round draft term does not match')
+        assert.equal(delayedTerms.toString(), lastTerm - draftTermId, 'delayed terms do not match')
+        assert.equal(roundJurorsNumber.toString(), firstRoundJurorsNumber, 'round jurors number does not match')
+        assert.equal(selectedJurors.toString(), firstRoundJurorsNumber, 'selected jurors does not match')
+        assert.equal(jurorFees.toString(), courtHelper.jurorFee.mul(bn(firstRoundJurorsNumber)).toString(), 'round juror fees do not match')
+        assert.equal(roundState.toString(), ROUND_STATES.COMMITTING.toString(), 'round state should be committing')
+      })
+
+      it('sets the correct state for each juror', async () => {
+        const expectedWeights = {}
+
+        for (let batch = 0; batch < batches; batch++) {
+          // advance one term to avoid drafting all the batches in the same term
+          await courtHelper.passRealTerms(1)
+          const receipt = await court.draft(disputeId, jurorsPerBatch, { from: drafter })
+
+          const logs = decodeEventsOfType(receipt, JurorsRegistry.abi, 'JurorDrafted')
+          const events = getEvents({ logs }, 'JurorDrafted')
 
           for(let i = 0; i < jurors.length; i++) {
             const jurorAddress = jurors[i].address
-            const { weight, rewarded } = await court.getJuror(disputeId, roundId, jurorAddress)
-
-            assert.equal(weight.toString(), expectedWeights[jurorAddress], `juror ${jurorAddress} weight does not match`)
-            assert.isFalse(rewarded, 'juror should not have been rewarded yet')
+            const batchWeight = events.filter(({ args: { juror } }) => toChecksumAddress(juror) === jurorAddress).length
+            expectedWeights[jurorAddress] = (expectedWeights[jurorAddress] || 0) + batchWeight
           }
-        })
+        }
 
-        it('deposits the draft fee to the accounting for the caller', async () => {
-          const { draftFee, accounting, feeToken } = courtHelper
+        for(let i = 0; i < jurors.length; i++) {
+          const jurorAddress = jurors[i].address
+          const { weight, rewarded } = await court.getJuror(disputeId, roundId, jurorAddress)
 
-          for (let batch = 0, selectedJurors = 0; batch < batches; batch++, selectedJurors += jurorsPerBatch) {
-            const previousCourtAmount = await feeToken.balanceOf(court.address)
-            const previousAccountingAmount = await feeToken.balanceOf(accounting.address)
-            const previousDrafterAmount = await accounting.balanceOf(feeToken.address, drafter)
+          assert.equal(weight.toString(), expectedWeights[jurorAddress], `juror ${jurorAddress} weight does not match`)
+          assert.isFalse(rewarded, 'juror should not have been rewarded yet')
+        }
+      })
 
-            // advance one term to avoid drafting all the batches in the same term
-            await courtHelper.passRealTerms(1)
-            await court.draft(disputeId, jurorsPerBatch, { from: drafter })
+      it('deposits the draft fee to the accounting for the caller', async () => {
+        const { draftFee, accounting, feeToken } = courtHelper
 
-            const currentCourtAmount = await feeToken.balanceOf(court.address)
-            assert.equal(previousCourtAmount.toString(), currentCourtAmount.toString(), 'court balances should remain the same')
+        for (let batch = 0, selectedJurors = 0; batch < batches; batch++, selectedJurors += jurorsPerBatch) {
+          const previousCourtAmount = await feeToken.balanceOf(court.address)
+          const previousAccountingAmount = await feeToken.balanceOf(accounting.address)
+          const previousDrafterAmount = await accounting.balanceOf(feeToken.address, drafter)
 
-            const currentAccountingAmount = await feeToken.balanceOf(accounting.address)
-            assert.equal(previousAccountingAmount.toString(), currentAccountingAmount.toString(), 'accounting balances should remain the same')
+          // advance one term to avoid drafting all the batches in the same term
+          await courtHelper.passRealTerms(1)
+          await court.draft(disputeId, jurorsPerBatch, { from: drafter })
 
-            const pendingJurorsToBeDrafted = jurorsToBeDrafted - selectedJurors
-            const expectedDraftedJurors = pendingJurorsToBeDrafted < jurorsPerBatch ? pendingJurorsToBeDrafted : jurorsPerBatch
-            const expectedFee = draftFee.mul(bn(expectedDraftedJurors))
-            const currentDrafterAmount = await accounting.balanceOf(feeToken.address, drafter)
-            assert.equal(previousDrafterAmount.add(expectedFee).toString(), currentDrafterAmount.toString(), 'drafter amount does not match')
-          }
-        })
-      }
+          const currentCourtAmount = await feeToken.balanceOf(court.address)
+          assert.equal(previousCourtAmount.toString(), currentCourtAmount.toString(), 'court balances should remain the same')
 
-      const itHandlesDraftsProperlyForDifferentRequestedJurorsNumber = term => {
-        context('when drafting all the requested jurors', () => {
-          const jurorsToBeDrafted = firstRoundJurorsNumber
+          const currentAccountingAmount = await feeToken.balanceOf(accounting.address)
+          assert.equal(previousAccountingAmount.toString(), currentAccountingAmount.toString(), 'accounting balances should remain the same')
 
-          context('when drafting in one batch', () => {
-            itDraftsRequestedRoundInOneBatch(term, jurorsToBeDrafted)
-          })
+          const pendingJurorsToBeDrafted = jurorsToBeDrafted - selectedJurors
+          const expectedDraftedJurors = pendingJurorsToBeDrafted < jurorsPerBatch ? pendingJurorsToBeDrafted : jurorsPerBatch
+          const expectedFee = draftFee.mul(bn(expectedDraftedJurors))
+          const currentDrafterAmount = await accounting.balanceOf(feeToken.address, drafter)
+          assert.equal(previousDrafterAmount.add(expectedFee).toString(), currentDrafterAmount.toString(), 'drafter amount does not match')
+        }
+      })
+    }
 
-          context('when drafting in multiple batches', () => {
-            const batches = 2, jurorsPerBatch = 4
+    const itHandlesDraftsProperlyForDifferentRequestedJurorsNumber = term => {
+      context('when drafting all the requested jurors', () => {
+        const jurorsToBeDrafted = firstRoundJurorsNumber
 
-            itDraftsRequestedRoundInMultipleBatches(term, jurorsToBeDrafted, batches, jurorsPerBatch)
-          })
-        })
-
-        context('when half amount of the requested jurors', () => {
-          const jurorsToBeDrafted = Math.floor(firstRoundJurorsNumber / 2)
-
+        context('when drafting in one batch', () => {
           itDraftsRequestedRoundInOneBatch(term, jurorsToBeDrafted)
         })
 
-        context('when drafting more than the requested jurors', () => {
-          const jurorsToBeDrafted = firstRoundJurorsNumber * 2
+        context('when drafting in multiple batches', () => {
+          const batches = 2, jurorsPerBatch = 4
 
-          itDraftsRequestedRoundInOneBatch(term, jurorsToBeDrafted)
+          itDraftsRequestedRoundInMultipleBatches(term, jurorsToBeDrafted, batches, jurorsPerBatch)
         })
-      }
+      })
 
-      const itHandlesDraftsProperly = term => {
-        // NOTE: To test this scenario we cannot mock the blocknumber, we need a real block mining to have different blockhashes
+      context('when half amount of the requested jurors', () => {
+        const jurorsToBeDrafted = Math.floor(firstRoundJurorsNumber / 2)
 
-        context('when the current block is the randomness block number', () => {
-          it('reverts', async () => {
-            await assertRevert(court.draft(disputeId, firstRoundJurorsNumber, { from: drafter }), 'CT_TERM_RANDOMNESS_NOT_YET')
-          })
+        itDraftsRequestedRoundInOneBatch(term, jurorsToBeDrafted)
+      })
+
+      context('when drafting more than the requested jurors', () => {
+        const jurorsToBeDrafted = firstRoundJurorsNumber * 2
+
+        itDraftsRequestedRoundInOneBatch(term, jurorsToBeDrafted)
+      })
+    }
+
+    const itHandlesDraftsProperly = term => {
+      // NOTE: To test this scenario we cannot mock the blocknumber, we need a real block mining to have different blockhashes
+
+      context('when the current block is the randomness block number', () => {
+        it('reverts', async () => {
+          await assertRevert(court.draft(disputeId, firstRoundJurorsNumber, { from: drafter }), 'CT_TERM_RANDOMNESS_NOT_YET')
         })
+      })
 
-        context('when the current block is the following block of the randomness block number', () => {
-          beforeEach('move one block after the draft term', async () => {
-            await advanceBlocks(1)
-          })
-
-          itHandlesDraftsProperlyForDifferentRequestedJurorsNumber(term)
-        })
-
-        context('when the current term is after the randomness block number by less than 256 blocks', () => {
-          beforeEach('move 255 blocks after the draft term', async () => {
-            await advanceBlocks(255)
-          })
-
-          itHandlesDraftsProperlyForDifferentRequestedJurorsNumber(term)
-        })
-
-        context('when the current term is after the randomness block number by 256 blocks', () => {
-          beforeEach('move 256 blocks after the draft term', async () => {
-            await advanceBlocks(256)
-          })
-
-          itHandlesDraftsProperlyForDifferentRequestedJurorsNumber(term)
+      context('when the current block is the following block of the randomness block number', () => {
+        beforeEach('move one block after the draft term', async () => {
+          await advanceBlocks(1)
         })
 
-        context('when the current term is after the randomness block number by more than 256 blocks', () => {
-          beforeEach('move 257 blocks after the draft term', async () => {
-            await advanceBlocks(257)
-          })
+        itHandlesDraftsProperlyForDifferentRequestedJurorsNumber(term)
+      })
 
-          it('reverts', async () => {
-            await assertRevert(court.draft(disputeId, firstRoundJurorsNumber, { from: drafter }), 'CT_TERM_RANDOMNESS_NOT_AVAILABLE')
-          })
-        })
-      }
-
-      const itHandlesDraftsProperlyForTerm = (term, expectsHeartbeatFees) => {
-        beforeEach('move to requested term', async () => {
-          // the first term was already ensured when creating the dispute
-          await courtHelper.increaseTime(courtHelper.termDuration.mul(bn(term - 1)))
+      context('when the current term is after the randomness block number by less than 256 blocks', () => {
+        beforeEach('move 255 blocks after the draft term', async () => {
+          await advanceBlocks(255)
         })
 
-        context('when the given dispute was not drafted', () => {
-          context('when the court term is up-to-date', () => {
-            beforeEach('ensure previous term of the draft term', async () => {
-              const neededTransitions = await court.neededTermTransitions()
-              await court.heartbeat(neededTransitions)
-            })
+        itHandlesDraftsProperlyForDifferentRequestedJurorsNumber(term)
+      })
 
-            itHandlesDraftsProperly(term)
+      context('when the current term is after the randomness block number by 256 blocks', () => {
+        beforeEach('move 256 blocks after the draft term', async () => {
+          await advanceBlocks(256)
+        })
+
+        itHandlesDraftsProperlyForDifferentRequestedJurorsNumber(term)
+      })
+
+      context('when the current term is after the randomness block number by more than 256 blocks', () => {
+        beforeEach('move 257 blocks after the draft term', async () => {
+          await advanceBlocks(257)
+        })
+
+        it('reverts', async () => {
+          await assertRevert(court.draft(disputeId, firstRoundJurorsNumber, { from: drafter }), 'CT_TERM_RANDOMNESS_NOT_AVAILABLE')
+        })
+      })
+    }
+
+    const itHandlesDraftsProperlyForTerm = (term, expectsHeartbeatFees) => {
+      beforeEach('move to requested term', async () => {
+        // the first term was already ensured when creating the dispute
+        await courtHelper.increaseTime(courtHelper.termDuration.mul(bn(term - 1)))
+      })
+
+      context('when the given dispute was not drafted', () => {
+        context('when the court term is up-to-date', () => {
+          beforeEach('ensure previous term of the draft term', async () => {
+            const neededTransitions = await court.neededTermTransitions()
+            await court.heartbeat(neededTransitions)
           })
 
-          context('when the court term is outdated by one term', () => {
-            beforeEach('ensure previous term of the draft term', async () => {
-              const neededTransitions = await court.neededTermTransitions()
-              await court.heartbeat(neededTransitions.sub(bn(1)))
-            })
+          itHandlesDraftsProperly(term)
+        })
 
-            context('when the heartbeat was not executed', async () => {
-              it('reverts', async () => {
-                await assertRevert(court.draft(disputeId, firstRoundJurorsNumber, { from: drafter }), 'CT_TERM_OUTDATED')
-              })
-            })
-
-            context('when the heartbeat was executed', async () => {
-              let lastEnsuredTermId, previousBalance, receipt
-
-              beforeEach('call heartbeat', async () => {
-                lastEnsuredTermId = await court.getLastEnsuredTermId()
-                previousBalance = await courtHelper.accounting.balanceOf(courtHelper.feeToken.address, drafter)
-                receipt = await court.heartbeat(1, { from: drafter })
-              })
-
-              it('transitions 1 term', async () => {
-                assertAmountOfEvents(receipt, 'NewTerm', 1)
-                assertEvent(receipt, 'NewTerm', { termId: lastEnsuredTermId.add(bn(1)), heartbeatSender: drafter })
-              })
-
-              it(`${expectsHeartbeatFees ? 'refunds' : 'does not refund'} heartbeat fees to the caller`, async () => {
-                const { feeToken, heartbeatFee } = courtHelper
-                const currentBalance = await courtHelper.accounting.balanceOf(feeToken.address, drafter)
-                const expectedBalance = expectsHeartbeatFees ? previousBalance.add(heartbeatFee) : previousBalance
-                assert.equal(currentBalance.toString(), expectedBalance.toString(), 'fee token balances does not match')
-              })
-
-              itHandlesDraftsProperly(term)
-            })
+        context('when the court term is outdated by one term', () => {
+          beforeEach('ensure previous term of the draft term', async () => {
+            const neededTransitions = await court.neededTermTransitions()
+            await court.heartbeat(neededTransitions.sub(bn(1)))
           })
 
-          context('when the court term is outdated by more than one term', () => {
-            beforeEach('advance some blocks to ensure term randomness', async () => {
-              await advanceBlocks(10)
-            })
-
+          context('when the heartbeat was not executed', async () => {
             it('reverts', async () => {
               await assertRevert(court.draft(disputeId, firstRoundJurorsNumber, { from: drafter }), 'CT_TERM_OUTDATED')
             })
           })
+
+          context('when the heartbeat was executed', async () => {
+            let lastEnsuredTermId, previousBalance, receipt
+
+            beforeEach('call heartbeat', async () => {
+              lastEnsuredTermId = await court.getLastEnsuredTermId()
+              previousBalance = await courtHelper.accounting.balanceOf(courtHelper.feeToken.address, drafter)
+              receipt = await court.heartbeat(1, { from: drafter })
+            })
+
+            it('transitions 1 term', async () => {
+              assertAmountOfEvents(receipt, 'NewTerm', 1)
+              assertEvent(receipt, 'NewTerm', { termId: lastEnsuredTermId.add(bn(1)), heartbeatSender: drafter })
+            })
+
+            it(`${expectsHeartbeatFees ? 'refunds' : 'does not refund'} heartbeat fees to the caller`, async () => {
+              const { feeToken, heartbeatFee } = courtHelper
+              const currentBalance = await courtHelper.accounting.balanceOf(feeToken.address, drafter)
+              const expectedBalance = expectsHeartbeatFees ? previousBalance.add(heartbeatFee) : previousBalance
+              assert.equal(currentBalance.toString(), expectedBalance.toString(), 'fee token balances does not match')
+            })
+
+            itHandlesDraftsProperly(term)
+          })
         })
 
-        context('when the given dispute was already drafted', () => {
-          beforeEach('draft dispute', async () => {
-            await court.heartbeat(term)
-            await advanceBlocks(10) // advance some blocks to ensure term randomness
-            await court.draft(disputeId, firstRoundJurorsNumber, { from: drafter })
+        context('when the court term is outdated by more than one term', () => {
+          beforeEach('advance some blocks to ensure term randomness', async () => {
+            await advanceBlocks(10)
           })
 
           it('reverts', async () => {
-            await assertRevert(court.draft(disputeId, firstRoundJurorsNumber, { from: drafter }), 'CT_ROUND_ALREADY_DRAFTED')
+            await assertRevert(court.draft(disputeId, firstRoundJurorsNumber, { from: drafter }), 'CT_TERM_OUTDATED')
           })
         })
-      }
+      })
 
-      context('when the current term is previous the draft term', () => {
+      context('when the given dispute was already drafted', () => {
+        beforeEach('draft dispute', async () => {
+          await court.heartbeat(term)
+          await advanceBlocks(10) // advance some blocks to ensure term randomness
+          await court.draft(disputeId, firstRoundJurorsNumber, { from: drafter })
+        })
+
         it('reverts', async () => {
-          await assertRevert(court.draft(disputeId, firstRoundJurorsNumber, { from: drafter }), 'CT_ROUND_NOT_DRAFT_TERM')
+          await assertRevert(court.draft(disputeId, firstRoundJurorsNumber, { from: drafter }), 'CT_ROUND_ALREADY_DRAFTED')
         })
       })
+    }
 
-      context('when the current term is the draft term', () => {
-        const currentTerm = draftTermId
-        const expectsHeartbeatFees = true
-
-        itHandlesDraftsProperlyForTerm(currentTerm, expectsHeartbeatFees)
-      })
-
-      context('when the current term is after the draft term', () => {
-        const currentTerm = draftTermId + 10
-        const expectsHeartbeatFees = false
-
-        itHandlesDraftsProperlyForTerm(currentTerm, expectsHeartbeatFees)
+    context('when the current term is previous the draft term', () => {
+      it('reverts', async () => {
+        await assertRevert(court.draft(disputeId, firstRoundJurorsNumber, { from: drafter }), 'CT_ROUND_NOT_DRAFT_TERM')
       })
     })
 
-    context('when the given dispute does not exist', () => {
-      it('reverts', async () => {
-        await assertRevert(court.draft(0, 10), 'CT_DISPUTE_DOES_NOT_EXIST')
-      })
+    context('when the current term is the draft term', () => {
+      const currentTerm = draftTermId
+      const expectsHeartbeatFees = true
+
+      itHandlesDraftsProperlyForTerm(currentTerm, expectsHeartbeatFees)
+    })
+
+    context('when the current term is after the draft term', () => {
+      const currentTerm = draftTermId + 10
+      const expectsHeartbeatFees = false
+
+      itHandlesDraftsProperlyForTerm(currentTerm, expectsHeartbeatFees)
+    })
+  })
+
+  context('when the given dispute does not exist', () => {
+    it('reverts', async () => {
+      await assertRevert(court.draft(0, 10), 'CT_DISPUTE_DOES_NOT_EXIST')
     })
   })
 })

--- a/test/court/court-initialize.js
+++ b/test/court/court-initialize.js
@@ -3,40 +3,38 @@ const { buildHelper } = require('../helpers/court')(web3, artifacts)
 const { NOW, ONE_DAY } = require('../helpers/time')
 const { assertRevert } = require('../helpers/assertThrow')
 
-contract('Court', () => {
+contract('Court (initialization)', () => {
   let courtHelper
 
   beforeEach('create court helper', async () => {
     courtHelper = buildHelper()
   })
 
-  describe('initialization', () => {
-    it('cannot use a term duration greater than the first term start time', async () => {
-      await assertRevert(courtHelper.deploy({ mockedTimestamp: NOW, firstTermStartTime: ONE_DAY, termDuration: ONE_DAY + 1 }), 'CT_BAD_FIRST_TERM_START_TIME')
+  it('cannot use a term duration greater than the first term start time', async () => {
+    await assertRevert(courtHelper.deploy({ mockedTimestamp: NOW, firstTermStartTime: ONE_DAY, termDuration: ONE_DAY + 1 }), 'CT_BAD_FIRST_TERM_START_TIME')
+  })
+
+  it('cannot use a first term start time in the past', async () => {
+    await assertRevert(courtHelper.deploy({ mockedTimestamp: NOW, firstTermStartTime: NOW - 1, termDuration: ONE_DAY }), 'CT_BAD_FIRST_TERM_START_TIME')
+  })
+
+  context('penalty pct (1/10,000)', () => {
+    it('cannot be above 100%', async () => {
+      await assertRevert(courtHelper.deploy({ penaltyPct: bn(10001) }), 'CT_INVALID_PENALTY_PCT')
     })
 
-    it('cannot use a first term start time in the past', async () => {
-      await assertRevert(courtHelper.deploy({ mockedTimestamp: NOW, firstTermStartTime: NOW - 1, termDuration: ONE_DAY }), 'CT_BAD_FIRST_TERM_START_TIME')
+    it('can be 0%', async () => {
+      const court = await courtHelper.deploy({ penaltyPct: bn(0) })
+      const termId = await court.getLastEnsuredTermId()
+      const { penaltyPct } = await courtHelper.getCourtConfig(termId)
+      assert.equal(penaltyPct.toString(), 0, 'penalty pct does not match')
     })
 
-    context('penalty pct (1/10,000)', () => {
-      it('cannot be above 100%', async () => {
-        await assertRevert(courtHelper.deploy({ penaltyPct: bn(10001) }), 'CT_INVALID_PENALTY_PCT')
-      })
-
-      it('can be 0%', async () => {
-        const court = await courtHelper.deploy({ penaltyPct: bn(0) })
-        const termId = await court.getLastEnsuredTermId()
-        const { penaltyPct } = await courtHelper.getCourtConfig(termId)
-        assert.equal(penaltyPct.toString(), 0, 'penalty pct does not match')
-      })
-
-      it('can be 100%', async () => {
-        const court = await courtHelper.deploy({ penaltyPct: bn(10000) })
-        const termId = await court.getLastEnsuredTermId()
-        const { penaltyPct } = await courtHelper.getCourtConfig(termId)
-        assert.equal(penaltyPct.toString(), 10000, 'penalty pct does not match')
-      })
+    it('can be 100%', async () => {
+      const court = await courtHelper.deploy({ penaltyPct: bn(10000) })
+      const termId = await court.getLastEnsuredTermId()
+      const { penaltyPct } = await courtHelper.getCourtConfig(termId)
+      assert.equal(penaltyPct.toString(), 10000, 'penalty pct does not match')
     })
   })
 })

--- a/test/court/court-settle.js
+++ b/test/court/court-settle.js
@@ -8,7 +8,7 @@ const { buildHelper, DEFAULTS, ROUND_STATES, DISPUTE_STATES } = require('../help
 
 const Arbitrable = artifacts.require('IArbitrable')
 
-contract('Court', ([_, disputer, drafter, appealMaker, appealTaker, juror500, juror1000, juror1500, juror2000, juror2500, juror3000, juror3500, juror4000, anyone]) => {
+contract('Court (settle)', ([_, disputer, drafter, appealMaker, appealTaker, juror500, juror1000, juror1500, juror2000, juror2500, juror3000, juror3500, juror4000, anyone]) => {
   let courtHelper, court, voting
 
   const jurors = [
@@ -29,322 +29,436 @@ contract('Court', ([_, disputer, drafter, appealMaker, appealTaker, juror500, ju
     voting = courtHelper.voting
   })
 
-  describe('settle', () => {
-    context('when the given dispute exists', () => {
-      let disputeId, voteId
-      const draftTermId = 4
+  context('when the given dispute exists', () => {
+    let disputeId, voteId
+    const draftTermId = 4
 
-      beforeEach('activate jurors and create dispute', async () => {
-        await courtHelper.activate(jurors)
+    beforeEach('activate jurors and create dispute', async () => {
+      await courtHelper.activate(jurors)
 
-        await courtHelper.setTerm(1)
-        disputeId = await courtHelper.dispute({ draftTermId, disputer })
-        await courtHelper.passTerms(bn(draftTermId - 1)) // court is already at term one
-      })
+      await courtHelper.setTerm(1)
+      disputeId = await courtHelper.dispute({ draftTermId, disputer })
+      await courtHelper.passTerms(bn(draftTermId - 1)) // court is already at term one
+    })
 
-      context('when the given round is valid', () => {
-        const roundId = 0
-        const voters = [
-          { address: juror1000, weight: 1, outcome: OUTCOMES.LEAKED },
-          { address: juror2000, weight: 1, outcome: OUTCOMES.HIGH },
-          { address: juror4000, weight: 1, outcome: OUTCOMES.LOW },
-        ]
+    context('when the given round is valid', () => {
+      const roundId = 0
+      const voters = [
+        { address: juror1000, weight: 1, outcome: OUTCOMES.LEAKED },
+        { address: juror2000, weight: 1, outcome: OUTCOMES.HIGH },
+        { address: juror4000, weight: 1, outcome: OUTCOMES.LOW },
+      ]
 
-        const itIsAtState = (roundId, state) => {
-          it(`round is at state ${state}`, async () => {
-            const { roundState } = await courtHelper.getRound(disputeId, roundId)
-            assert.equal(roundState.toString(), state.toString(), 'round state does not match')
+      const itIsAtState = (roundId, state) => {
+        it(`round is at state ${state}`, async () => {
+          const { roundState } = await courtHelper.getRound(disputeId, roundId)
+          assert.equal(roundState.toString(), state.toString(), 'round state does not match')
+        })
+      }
+
+      const itFailsToExecuteRuling = () => {
+        it('fails to execute ruling', async () => {
+          await assertRevert(court.executeRuling(disputeId), 'CT_INVALID_ADJUDICATION_STATE')
+        })
+      }
+
+      const itFailsToSettlePenalties = (roundId) => {
+        it('fails to settle penalties', async () => {
+          await assertRevert(court.settlePenalties(disputeId, roundId, firstRoundJurorsNumber), 'CT_INVALID_ADJUDICATION_STATE')
+        })
+      }
+
+      const itFailsToSettleRewards = (roundId) => {
+        it('fails to settle rewards', async () => {
+          await assertRevert(court.settleReward(disputeId, roundId, anyone), 'CT_ROUND_PENALTIES_NOT_SETTLED')
+        })
+      }
+
+      const itFailsToSettleAppealDeposits = (roundId) => {
+        it('fails to settle appeal deposits', async () => {
+          await assertRevert(court.settleAppealDeposit(disputeId, roundId), 'CT_ROUND_PENALTIES_NOT_SETTLED')
+        })
+      }
+
+      const itFailsToSettleAll = (roundId) => {
+        itFailsToSettlePenalties(roundId)
+        itFailsToSettleRewards(roundId)
+        itFailsToSettleAppealDeposits(roundId)
+      }
+
+      const itExecutesFinalRulingProperly = expectedFinalRuling => {
+        describe('executeRuling', () => {
+          it('emits an event', async () => {
+            const receipt = await court.executeRuling(disputeId)
+
+            assertAmountOfEvents(receipt, 'RulingExecuted')
+            assertEvent(receipt, 'RulingExecuted', { disputeId, ruling: expectedFinalRuling })
           })
-        }
 
-        const itFailsToExecuteRuling = () => {
-          it('fails to execute ruling', async () => {
-            await assertRevert(court.executeRuling(disputeId), 'CT_INVALID_ADJUDICATION_STATE')
+          it('executes the associated arbitrable', async () => {
+            const receipt = await court.executeRuling(disputeId)
+
+            const logs = decodeEventsOfType(receipt, Arbitrable.abi, 'CourtRuling')
+            assertAmountOfEvents({ logs }, 'CourtRuling')
+            assertEvent({ logs }, 'CourtRuling', { court: court.address, disputeId, ruling: expectedFinalRuling })
           })
-        }
 
-        const itFailsToSettlePenalties = (roundId) => {
-          it('fails to settle penalties', async () => {
-            await assertRevert(court.settlePenalties(disputeId, roundId, firstRoundJurorsNumber), 'CT_INVALID_ADJUDICATION_STATE')
+          it('marks the dispute as executed', async () => {
+            await court.executeRuling(disputeId)
+
+            const { possibleRulings, state, finalRuling } = await courtHelper.getDispute(disputeId)
+            assert.equal(state.toString(), DISPUTE_STATES.EXECUTED.toString(), 'dispute state does not match')
+            assert.equal(possibleRulings.toString(), 2, 'dispute possible rulings do not match')
+            assert.equal(finalRuling.toString(), expectedFinalRuling.toString(), 'dispute final ruling does not match')
           })
-        }
 
-        const itFailsToSettleRewards = (roundId) => {
-          it('fails to settle rewards', async () => {
-            await assertRevert(court.settleReward(disputeId, roundId, anyone), 'CT_ROUND_PENALTIES_NOT_SETTLED')
+          it('cannot be executed twice', async () => {
+            await court.executeRuling(disputeId)
+
+            await assertRevert(court.executeRuling(disputeId), 'CT_INVALID_DISPUTE_STATE')
           })
-        }
+        })
+      }
 
-        const itFailsToSettleAppealDeposits = (roundId) => {
-          it('fails to settle appeal deposits', async () => {
-            await assertRevert(court.settleAppealDeposit(disputeId, roundId), 'CT_ROUND_PENALTIES_NOT_SETTLED')
-          })
-        }
+      const itSettlesPenaltiesAndRewardsProperly = (roundId, expectedWinningJurors, expectedLosingJurors) => {
+        let previousBalances = {}, expectedCoherentJurors, expectedCollectedTokens
 
-        const itFailsToSettleAll = (roundId) => {
-          itFailsToSettlePenalties(roundId)
-          itFailsToSettleRewards(roundId)
-          itFailsToSettleAppealDeposits(roundId)
-        }
+        beforeEach('load previous balances', async () => {
+          previousBalances = {}
+          for (const { address } of jurors) {
+            const { active, available, locked } = await courtHelper.jurorsRegistry.balanceOf(address)
+            previousBalances[address] = { active, available, locked }
+          }
+        })
 
-        const itExecutesFinalRulingProperly = expectedFinalRuling => {
-          describe('executeRuling', () => {
-            it('emits an event', async () => {
-              const receipt = await court.executeRuling(disputeId)
-
-              assertAmountOfEvents(receipt, 'RulingExecuted')
-              assertEvent(receipt, 'RulingExecuted', { disputeId, ruling: expectedFinalRuling })
-            })
-
-            it('executes the associated arbitrable', async () => {
-              const receipt = await court.executeRuling(disputeId)
-
-              const logs = decodeEventsOfType(receipt, Arbitrable.abi, 'CourtRuling')
-              assertAmountOfEvents({ logs }, 'CourtRuling')
-              assertEvent({ logs }, 'CourtRuling', { court: court.address, disputeId, ruling: expectedFinalRuling })
-            })
-
-            it('marks the dispute as executed', async () => {
-              await court.executeRuling(disputeId)
-
-              const { possibleRulings, state, finalRuling } = await courtHelper.getDispute(disputeId)
-              assert.equal(state.toString(), DISPUTE_STATES.EXECUTED.toString(), 'dispute state does not match')
-              assert.equal(possibleRulings.toString(), 2, 'dispute possible rulings do not match')
-              assert.equal(finalRuling.toString(), expectedFinalRuling.toString(), 'dispute final ruling does not match')
-            })
-
-            it('cannot be executed twice', async () => {
-              await court.executeRuling(disputeId)
-
-              await assertRevert(court.executeRuling(disputeId), 'CT_INVALID_DISPUTE_STATE')
-            })
-          })
-        }
-
-        const itSettlesPenaltiesAndRewardsProperly = (roundId, expectedWinningJurors, expectedLosingJurors) => {
-          let previousBalances = {}, expectedCoherentJurors, expectedCollectedTokens
-
-          beforeEach('load previous balances', async () => {
-            previousBalances = {}
-            for (const { address } of jurors) {
-              const { active, available, locked } = await courtHelper.jurorsRegistry.balanceOf(address)
-              previousBalances[address] = { active, available, locked }
+        beforeEach('load expected coherent jurors', async () => {
+          // for final rounds compute voter's weight
+          if (roundId >= courtHelper.maxRegularAppealRounds.toNumber()) {
+            for (const juror of expectedWinningJurors) {
+              juror.weight = (await courtHelper.getFinalRoundWeight(disputeId, roundId, juror.address)).toNumber()
             }
-          })
+          }
 
-          beforeEach('load expected coherent jurors', async () => {
-            // for final rounds compute voter's weight
-            if (roundId >= courtHelper.maxRegularAppealRounds.toNumber()) {
-              for (const juror of expectedWinningJurors) {
-                juror.weight = (await courtHelper.getFinalRoundWeight(disputeId, roundId, juror.address)).toNumber()
-              }
-            }
+          expectedCoherentJurors = expectedWinningJurors.reduce((total, { weight }) => total + weight, 0)
 
-            expectedCoherentJurors = expectedWinningJurors.reduce((total, { weight }) => total + weight, 0)
+          expectedCollectedTokens = bn(0)
+          for (const { address } of expectedLosingJurors) {
+            const roundLockedBalance = await courtHelper.getRoundLockBalance(disputeId, roundId, address)
+            expectedCollectedTokens = expectedCollectedTokens.add(roundLockedBalance)
+          }
 
-            expectedCollectedTokens = bn(0)
-            for (const { address } of expectedLosingJurors) {
+          // for final rounds all voter's tokens are collected before hand, then, add the balances of the winning jurors as well
+          if (roundId >= courtHelper.maxRegularAppealRounds.toNumber()) {
+            for (const { address } of expectedWinningJurors) {
               const roundLockedBalance = await courtHelper.getRoundLockBalance(disputeId, roundId, address)
               expectedCollectedTokens = expectedCollectedTokens.add(roundLockedBalance)
             }
+          }
+        })
 
-            // for final rounds all voter's tokens are collected before hand, then, add the balances of the winning jurors as well
-            if (roundId >= courtHelper.maxRegularAppealRounds.toNumber()) {
+        describe('settlePenalties', () => {
+          let receipt
+
+          const itSettlesPenaltiesProperly = () => {
+            it('unlocks the locked balances of the winning jurors', async () => {
               for (const { address } of expectedWinningJurors) {
                 const roundLockedBalance = await courtHelper.getRoundLockBalance(disputeId, roundId, address)
-                expectedCollectedTokens = expectedCollectedTokens.add(roundLockedBalance)
+
+                const { locked: previousLockedBalance, active: previousActiveBalance } = previousBalances[address]
+                const { active: currentActiveBalance, locked: currentLockedBalance } =await courtHelper.jurorsRegistry.balanceOf(address)
+                assert.equal(currentActiveBalance.toString(), previousActiveBalance.toString(), 'current active balance does not match')
+
+                // for the final round tokens are slashed before hand, thus they are not considered as locked tokens
+                const expectedLockedBalance = roundId < courtHelper.maxRegularAppealRounds ? previousLockedBalance.sub(roundLockedBalance).toString() : 0
+                assert.equal(currentLockedBalance.toString(), expectedLockedBalance, 'current locked balance does not match')
               }
-            }
+            })
+
+            it('slashes the losing jurors', async () => {
+              for (const { address } of expectedLosingJurors) {
+                const roundLockedBalance = await courtHelper.getRoundLockBalance(disputeId, roundId, address)
+
+                const { locked: previousLockedBalance, active: previousActiveBalance } = previousBalances[address]
+                const { active: currentActiveBalance, locked: currentLockedBalance } =await courtHelper.jurorsRegistry.balanceOf(address)
+
+                // for the final round tokens are slashed before hand, thus the active tokens for slashed jurors stays equal
+                const expectedActiveBalance = roundId < courtHelper.maxRegularAppealRounds
+                      ? previousActiveBalance.sub(roundLockedBalance)
+                      : previousActiveBalance
+                assert.equal(currentActiveBalance.toString(), expectedActiveBalance.toString(), 'current active balance does not match')
+
+                // for the final round tokens are slashed before hand, thus they are not considered as locked tokens
+                const expectedLockedBalance = roundId < courtHelper.maxRegularAppealRounds
+                      ? previousLockedBalance.sub(roundLockedBalance)
+                      : 0
+                assert.equal(currentLockedBalance.toString(), expectedLockedBalance.toString(), 'current locked balance does not match')
+              }
+            })
+
+            it('emits an event', async () => {
+              assertAmountOfEvents(receipt, 'PenaltiesSettled')
+              assertEvent(receipt, 'PenaltiesSettled', { disputeId, roundId, collectedTokens: expectedCollectedTokens })
+            })
+
+            it('updates the given round', async () => {
+              const { settledPenalties, collectedTokens, coherentJurors } = await courtHelper.getRound(disputeId, roundId)
+              assert.equal(settledPenalties, true, 'current round penalties should be settled')
+              assert.equal(collectedTokens.toString(), expectedCollectedTokens.toString(), 'current round collected tokens does not match')
+              assert.equal(coherentJurors.toString(), expectedCoherentJurors, 'current round coherent jurors does not match')
+            })
+
+            it('cannot be settled twice', async () => {
+              await assertRevert(court.settlePenalties(disputeId, roundId, 0), 'CT_ROUND_ALREADY_SETTLED')
+            })
+          }
+
+          context('when settling in one batch', () => {
+            beforeEach('settle penalties', async () => {
+              receipt = await court.settlePenalties(disputeId, roundId, 0)
+            })
+
+            itSettlesPenaltiesProperly()
           })
 
-          describe('settlePenalties', () => {
-            let receipt
-
-            const itSettlesPenaltiesProperly = () => {
-              it('unlocks the locked balances of the winning jurors', async () => {
-                for (const { address } of expectedWinningJurors) {
-                  const roundLockedBalance = await courtHelper.getRoundLockBalance(disputeId, roundId, address)
-
-                  const { locked: previousLockedBalance, active: previousActiveBalance } = previousBalances[address]
-                  const { active: currentActiveBalance, locked: currentLockedBalance } =await courtHelper.jurorsRegistry.balanceOf(address)
-                  assert.equal(currentActiveBalance.toString(), previousActiveBalance.toString(), 'current active balance does not match')
-
-                  // for the final round tokens are slashed before hand, thus they are not considered as locked tokens
-                  const expectedLockedBalance = roundId < courtHelper.maxRegularAppealRounds ? previousLockedBalance.sub(roundLockedBalance).toString() : 0
-                  assert.equal(currentLockedBalance.toString(), expectedLockedBalance, 'current locked balance does not match')
-                }
-              })
-
-              it('slashes the losing jurors', async () => {
-                for (const { address } of expectedLosingJurors) {
-                  const roundLockedBalance = await courtHelper.getRoundLockBalance(disputeId, roundId, address)
-
-                  const { locked: previousLockedBalance, active: previousActiveBalance } = previousBalances[address]
-                  const { active: currentActiveBalance, locked: currentLockedBalance } =await courtHelper.jurorsRegistry.balanceOf(address)
-
-                  // for the final round tokens are slashed before hand, thus the active tokens for slashed jurors stays equal
-                  const expectedActiveBalance = roundId < courtHelper.maxRegularAppealRounds
-                    ? previousActiveBalance.sub(roundLockedBalance)
-                    : previousActiveBalance
-                  assert.equal(currentActiveBalance.toString(), expectedActiveBalance.toString(), 'current active balance does not match')
-
-                  // for the final round tokens are slashed before hand, thus they are not considered as locked tokens
-                  const expectedLockedBalance = roundId < courtHelper.maxRegularAppealRounds
-                    ? previousLockedBalance.sub(roundLockedBalance)
-                    : 0
-                  assert.equal(currentLockedBalance.toString(), expectedLockedBalance.toString(), 'current locked balance does not match')
-                }
-              })
-
-              it('emits an event', async () => {
-                assertAmountOfEvents(receipt, 'PenaltiesSettled')
-                assertEvent(receipt, 'PenaltiesSettled', { disputeId, roundId, collectedTokens: expectedCollectedTokens })
-              })
-
-              it('updates the given round', async () => {
-                const { settledPenalties, collectedTokens, coherentJurors } = await courtHelper.getRound(disputeId, roundId)
-                assert.equal(settledPenalties, true, 'current round penalties should be settled')
-                assert.equal(collectedTokens.toString(), expectedCollectedTokens.toString(), 'current round collected tokens does not match')
-                assert.equal(coherentJurors.toString(), expectedCoherentJurors, 'current round coherent jurors does not match')
-              })
-
-              it('cannot be settled twice', async () => {
-                await assertRevert(court.settlePenalties(disputeId, roundId, 0), 'CT_ROUND_ALREADY_SETTLED')
-              })
-            }
-
-            context('when settling in one batch', () => {
+          context('when settling in multiple batches', () => {
+            if (roundId < DEFAULTS.maxRegularAppealRounds.toNumber()) {
               beforeEach('settle penalties', async () => {
-                receipt = await court.settlePenalties(disputeId, roundId, 0)
+                const batches = expectedWinningJurors.length + expectedLosingJurors.length
+                for (let batch = 0; batch < batches; batch++) {
+                  receipt = await court.settlePenalties(disputeId, roundId, 1)
+                  // assert round is not settle in the middle batches
+                  if (batch < batches - 1) assertAmountOfEvents(receipt, 'PenaltiesSettled', 0)
+                }
               })
 
               itSettlesPenaltiesProperly()
-            })
 
-            context('when settling in multiple batches', () => {
-              if (roundId < DEFAULTS.maxRegularAppealRounds.toNumber()) {
-                beforeEach('settle penalties', async () => {
-                  const batches = expectedWinningJurors.length + expectedLosingJurors.length
-                  for (let batch = 0; batch < batches; batch++) {
-                    receipt = await court.settlePenalties(disputeId, roundId, 1)
-                    // assert round is not settle in the middle batches
-                    if (batch < batches - 1) assertAmountOfEvents(receipt, 'PenaltiesSettled', 0)
-                  }
-                })
+            } else {
+              it('reverts', async () => {
+                await court.settlePenalties(disputeId, roundId, 1)
 
-                itSettlesPenaltiesProperly()
-
-              } else {
-                it('reverts', async () => {
-                  await court.settlePenalties(disputeId, roundId, 1)
-
-                  await assertRevert(court.settlePenalties(disputeId, roundId, 1), 'CT_ROUND_ALREADY_SETTLED')
-                })
-              }
-            })
+                await assertRevert(court.settlePenalties(disputeId, roundId, 1), 'CT_ROUND_ALREADY_SETTLED')
+              })
+            }
           })
+        })
 
-          describe('settleReward', () => {
-            context('when penalties have been settled', () => {
-              beforeEach('settle penalties', async () => {
-                await court.settlePenalties(disputeId, roundId, 0)
+        describe('settleReward', () => {
+          context('when penalties have been settled', () => {
+            beforeEach('settle penalties', async () => {
+              await court.settlePenalties(disputeId, roundId, 0)
+            })
+
+            if (expectedWinningJurors.length > 0) {
+              it('emits an event for each juror', async () => {
+                for(const { address } of expectedWinningJurors) {
+                  const receipt = await court.settleReward(disputeId, roundId, address)
+
+                  assertAmountOfEvents(receipt, 'RewardSettled')
+                  assertEvent(receipt, 'RewardSettled', { disputeId, roundId, juror: address })
+                }
               })
 
-              if (expectedWinningJurors.length > 0) {
-                it('emits an event for each juror', async () => {
-                  for(const { address } of expectedWinningJurors) {
-                    const receipt = await court.settleReward(disputeId, roundId, address)
-
-                    assertAmountOfEvents(receipt, 'RewardSettled')
-                    assertEvent(receipt, 'RewardSettled', { disputeId, roundId, juror: address })
-                  }
-                })
-
-                it('rewards the winning jurors', async () => {
-                  for(const { address, weight } of expectedWinningJurors) {
-                    await court.settleReward(disputeId, roundId, address)
-
-                    const { available } = await courtHelper.jurorsRegistry.balanceOf(address)
-                    const expectedReward = expectedCollectedTokens.mul(bn(weight)).div(bn(expectedCoherentJurors))
-                    const expectedCurrentAvailableBalance = previousBalances[address].available.add(expectedReward)
-
-                    assert.equal(expectedCurrentAvailableBalance.toString(), available.toString(), 'current available balance does not match')
-                  }
-                })
-
-                it('rewards winning jurors with fees', async () => {
-                  const { accounting, feeToken } = courtHelper
-                  const { jurorFees } = await courtHelper.getRound(disputeId, roundId)
-
-                  for(const { address, weight } of expectedWinningJurors) {
-                    const previousJurorBalance = await accounting.balanceOf(feeToken.address, address)
-
-                    await court.settleReward(disputeId, roundId, address)
-
-                    const expectedReward = jurorFees.mul(bn(weight)).div(bn(expectedCoherentJurors))
-                    const currentJurorBalance = await accounting.balanceOf(feeToken.address, address)
-                    assert.equal(currentJurorBalance.toString(), previousJurorBalance.add(expectedReward), 'juror fee balance does not match')
-                  }
-                })
-
-                it('updates the juror state of the round', async () => {
-                  for(const { address, weight } of expectedWinningJurors) {
-                    await court.settleReward(disputeId, roundId, address)
-
-                    const { weight: actualWeight, rewarded } = await courtHelper.getRoundJuror(disputeId, roundId, address)
-                    assert.isTrue(rewarded, 'juror should have been rewarded')
-                    assert.equal(actualWeight.toString(), weight, 'juror weight should not have changed')
-                  }
-                })
-
-                it('does not allow settling non-winning jurors', async () => {
-                  for(const { address } of expectedLosingJurors) {
-                    await assertRevert(court.settleReward(disputeId, roundId, address), 'CT_WONT_REWARD_INCOHERENT_JUROR')
-                  }
-                })
-
-                it('cannot be settled twice', async () => {
-                  const { address } = expectedWinningJurors[0]
+              it('rewards the winning jurors', async () => {
+                for(const { address, weight } of expectedWinningJurors) {
                   await court.settleReward(disputeId, roundId, address)
 
-                  await assertRevert(court.settleReward(disputeId, roundId, address), 'CT_JUROR_ALREADY_REWARDED')
-                })
-              } else {
-                it('does not allow settling non-winning jurors', async () => {
-                  for(const { address } of expectedLosingJurors) {
-                    await assertRevert(court.settleReward(disputeId, roundId, address), 'CT_WONT_REWARD_INCOHERENT_JUROR')
-                  }
-                })
+                  const { available } = await courtHelper.jurorsRegistry.balanceOf(address)
+                  const expectedReward = expectedCollectedTokens.mul(bn(weight)).div(bn(expectedCoherentJurors))
+                  const expectedCurrentAvailableBalance = previousBalances[address].available.add(expectedReward)
+
+                  assert.equal(expectedCurrentAvailableBalance.toString(), available.toString(), 'current available balance does not match')
+                }
+              })
+
+              it('rewards winning jurors with fees', async () => {
+                const { accounting, feeToken } = courtHelper
+                const { jurorFees } = await courtHelper.getRound(disputeId, roundId)
+
+                for(const { address, weight } of expectedWinningJurors) {
+                  const previousJurorBalance = await accounting.balanceOf(feeToken.address, address)
+
+                  await court.settleReward(disputeId, roundId, address)
+
+                  const expectedReward = jurorFees.mul(bn(weight)).div(bn(expectedCoherentJurors))
+                  const currentJurorBalance = await accounting.balanceOf(feeToken.address, address)
+                  assert.equal(currentJurorBalance.toString(), previousJurorBalance.add(expectedReward), 'juror fee balance does not match')
+                }
+              })
+
+              it('updates the juror state of the round', async () => {
+                for(const { address, weight } of expectedWinningJurors) {
+                  await court.settleReward(disputeId, roundId, address)
+
+                  const { weight: actualWeight, rewarded } = await courtHelper.getRoundJuror(disputeId, roundId, address)
+                  assert.isTrue(rewarded, 'juror should have been rewarded')
+                  assert.equal(actualWeight.toString(), weight, 'juror weight should not have changed')
+                }
+              })
+
+              it('does not allow settling non-winning jurors', async () => {
+                for(const { address } of expectedLosingJurors) {
+                  await assertRevert(court.settleReward(disputeId, roundId, address), 'CT_WONT_REWARD_INCOHERENT_JUROR')
+                }
+              })
+
+              it('cannot be settled twice', async () => {
+                const { address } = expectedWinningJurors[0]
+                await court.settleReward(disputeId, roundId, address)
+
+                await assertRevert(court.settleReward(disputeId, roundId, address), 'CT_JUROR_ALREADY_REWARDED')
+              })
+            } else {
+              it('does not allow settling non-winning jurors', async () => {
+                for(const { address } of expectedLosingJurors) {
+                  await assertRevert(court.settleReward(disputeId, roundId, address), 'CT_WONT_REWARD_INCOHERENT_JUROR')
+                }
+              })
+            }
+
+            it('does not allow settling non-voting jurors', async () => {
+              const nonVoters = filterJurors(jurors, expectedWinningJurors.concat(expectedLosingJurors))
+
+              for(const { address } of nonVoters) {
+                await assertRevert(court.settleReward(disputeId, roundId, address), 'CT_WONT_REWARD_NON_VOTER_JUROR')
               }
-
-              it('does not allow settling non-voting jurors', async () => {
-                const nonVoters = filterJurors(jurors, expectedWinningJurors.concat(expectedLosingJurors))
-
-                for(const { address } of nonVoters) {
-                  await assertRevert(court.settleReward(disputeId, roundId, address), 'CT_WONT_REWARD_NON_VOTER_JUROR')
-                }
-              })
-            })
-
-            context('when penalties have not been settled yet', () => {
-              it('reverts', async () => {
-                for (const { address } of expectedWinningJurors) {
-                  await assertRevert(court.settleReward(disputeId, roundId, address), 'CT_ROUND_PENALTIES_NOT_SETTLED')
-                }
-              })
             })
           })
-        }
 
-        const itCannotSettleAppealDeposits = (roundId) => {
+          context('when penalties have not been settled yet', () => {
+            it('reverts', async () => {
+              for (const { address } of expectedWinningJurors) {
+                await assertRevert(court.settleReward(disputeId, roundId, address), 'CT_ROUND_PENALTIES_NOT_SETTLED')
+              }
+            })
+          })
+        })
+      }
+
+      const itCannotSettleAppealDeposits = (roundId) => {
+        describe('settleAppealDeposit', () => {
+          context('when penalties have been settled', () => {
+            beforeEach('settle penalties', async () => {
+              await court.settlePenalties(disputeId, roundId, 0)
+            })
+
+            it('reverts', async () => {
+              await assertRevert(court.settleAppealDeposit(disputeId, roundId), 'CT_ROUND_NOT_APPEALED')
+            })
+          })
+
+          context('when penalties have not been settled yet', () => {
+            it('reverts', async () => {
+              await assertRevert(court.settleAppealDeposit(disputeId, roundId), 'CT_ROUND_PENALTIES_NOT_SETTLED')
+            })
+          })
+        })
+      }
+
+      beforeEach('mock draft round', async () => {
+        voteId = getVoteId(disputeId, roundId)
+        await courtHelper.draft({ disputeId, drafter, draftedJurors: voters })
+      })
+
+      context('during commit period', () => {
+        itIsAtState(roundId, ROUND_STATES.COMMITTING)
+        itFailsToExecuteRuling()
+        itFailsToSettleAll(roundId)
+      })
+
+      context('during reveal period', () => {
+        beforeEach('commit votes', async () => {
+          await courtHelper.commit({ disputeId, roundId, voters })
+        })
+
+        itIsAtState(roundId, ROUND_STATES.REVEALING)
+        itFailsToExecuteRuling()
+        itFailsToSettleAll(roundId)
+      })
+
+      context('during appeal period', () => {
+        beforeEach('commit and reveal votes', async () => {
+          await courtHelper.commit({ disputeId, roundId, voters })
+          await courtHelper.reveal({ disputeId, roundId, voters })
+        })
+
+        itIsAtState(roundId, ROUND_STATES.APPEALING)
+        itFailsToExecuteRuling()
+        itFailsToSettleAll(roundId)
+      })
+
+      context('during the appeal confirmation period', () => {
+        beforeEach('commit and reveal votes', async () => {
+          await courtHelper.commit({ disputeId, roundId, voters })
+          await courtHelper.reveal({ disputeId, roundId, voters })
+        })
+
+        context('when the round was not appealed', () => {
+          const expectedFinalRuling = OUTCOMES.LOW
+          const expectedWinningJurors = voters.filter(({ outcome }) => outcome === expectedFinalRuling)
+          const expectedLosingJurors = filterJurors(voters, expectedWinningJurors)
+
+          beforeEach('pass appeal period', async () => {
+            await courtHelper.passTerms(courtHelper.appealTerms)
+          })
+
+          itIsAtState(roundId, ROUND_STATES.ENDED)
+          itExecutesFinalRulingProperly(expectedFinalRuling)
+          itSettlesPenaltiesAndRewardsProperly(roundId, expectedWinningJurors, expectedLosingJurors)
+          itCannotSettleAppealDeposits(roundId)
+        })
+
+        context('when the round was appealed', () => {
+          beforeEach('appeal', async () => {
+            await courtHelper.appeal({ disputeId, roundId, appealMaker })
+          })
+
+          itIsAtState(roundId, ROUND_STATES.CONFIRMING_APPEAL)
+          itFailsToExecuteRuling()
+          itFailsToSettleAll(roundId)
+        })
+      })
+
+      context('after the appeal confirmation period', () => {
+        beforeEach('commit and reveal votes', async () => {
+          await courtHelper.commit({ disputeId, roundId, voters })
+          await courtHelper.reveal({ disputeId, roundId, voters })
+        })
+
+        const itSettlesAppealDeposits = (roundId, itTransferAppealsDeposits) => {
           describe('settleAppealDeposit', () => {
             context('when penalties have been settled', () => {
               beforeEach('settle penalties', async () => {
                 await court.settlePenalties(disputeId, roundId, 0)
               })
 
-              it('reverts', async () => {
-                await assertRevert(court.settleAppealDeposit(disputeId, roundId), 'CT_ROUND_NOT_APPEALED')
+              itTransferAppealsDeposits()
+
+              it('emits an event', async () => {
+                const receipt = await court.settleAppealDeposit(disputeId, roundId)
+
+                assertAmountOfEvents(receipt, 'AppealDepositSettled')
+                assertEvent(receipt, 'AppealDepositSettled', { disputeId, roundId })
+              })
+
+              it('does not affect the balances of the court', async () => {
+                const { accounting, feeToken } = courtHelper
+                const previousCourtBalance = await feeToken.balanceOf(court.address)
+                const previousAccountingBalance = await feeToken.balanceOf(accounting.address)
+
+                await court.settleAppealDeposit(disputeId, roundId)
+
+                const currentCourtBalance = await feeToken.balanceOf(court.address)
+                assert.equal(previousCourtBalance.toString(), currentCourtBalance.toString(), 'court balances do not match')
+
+                const currentAccountingBalance = await feeToken.balanceOf(accounting.address)
+                assert.equal(previousAccountingBalance.toString(), currentAccountingBalance.toString(), 'court accounting balances do not match')
+              })
+
+              it('cannot be settled twice', async () => {
+                await court.settleAppealDeposit(disputeId, roundId)
+
+                await assertRevert(court.settleAppealDeposit(disputeId, roundId), 'CT_APPEAL_ALREADY_SETTLED')
               })
             })
 
@@ -356,424 +470,308 @@ contract('Court', ([_, disputer, drafter, appealMaker, appealTaker, juror500, ju
           })
         }
 
-        beforeEach('mock draft round', async () => {
-          voteId = getVoteId(disputeId, roundId)
-          await courtHelper.draft({ disputeId, drafter, draftedJurors: voters })
-        })
+        const itReturnsAppealDepositsToMaker = (roundId) => {
+          itSettlesAppealDeposits(roundId, () => {
+            it('returns the deposit to the appeal maker', async () => {
+              const { accounting, feeToken } = courtHelper
+              const { appealDeposit } = await courtHelper.getAppealFees(disputeId, roundId)
 
-        context('during commit period', () => {
-          itIsAtState(roundId, ROUND_STATES.COMMITTING)
-          itFailsToExecuteRuling()
-          itFailsToSettleAll(roundId)
-        })
+              const previousBalance = await accounting.balanceOf(feeToken.address, appealMaker)
 
-        context('during reveal period', () => {
-          beforeEach('commit votes', async () => {
-            await courtHelper.commit({ disputeId, roundId, voters })
+              await court.settleAppealDeposit(disputeId, roundId)
+
+              const currentBalance = await accounting.balanceOf(feeToken.address, appealMaker)
+              assert.equal(previousBalance.add(appealDeposit).toString(), currentBalance.toString(), 'appeal maker balances do not match')
+            })
+          })
+        }
+
+        const itSettlesAppealDepositsToMaker = (roundId) => {
+          itSettlesAppealDeposits(roundId, () => {
+            it('settles the total deposit to the appeal taker', async () => {
+              const { accounting, feeToken } = courtHelper
+              const { appealFees, appealDeposit, confirmAppealDeposit } = await courtHelper.getAppealFees(disputeId, roundId)
+
+              const expectedAppealReward = appealDeposit.add(confirmAppealDeposit).sub(appealFees)
+              const previousAppealTakerBalance = await accounting.balanceOf(feeToken.address, appealTaker)
+
+              await court.settleAppealDeposit(disputeId, roundId)
+
+              const currentAppealTakerBalance = await accounting.balanceOf(feeToken.address, appealTaker)
+              assert.equal(previousAppealTakerBalance.add(expectedAppealReward).toString(), currentAppealTakerBalance.toString(), 'appeal maker balances do not match')
+            })
+          })
+        }
+
+        const itSettlesAppealDepositsToTaker = (roundId) => {
+          itSettlesAppealDeposits(roundId, () => {
+            it('settles the total deposit to the appeal maker', async () => {
+              const { accounting, feeToken } = courtHelper
+              const { appealFees, appealDeposit, confirmAppealDeposit } = await courtHelper.getAppealFees(disputeId, roundId)
+
+              const expectedAppealReward = appealDeposit.add(confirmAppealDeposit).sub(appealFees)
+              const previousAppealMakerBalance = await accounting.balanceOf(feeToken.address, appealMaker)
+
+              await court.settleAppealDeposit(disputeId, roundId)
+
+              const currentAppealMakerBalance = await accounting.balanceOf(feeToken.address, appealMaker)
+              assert.equal(previousAppealMakerBalance.add(expectedAppealReward).toString(), currentAppealMakerBalance.toString(), 'appeal maker balances do not match')
+            })
+          })
+        }
+
+        const itReturnsAppealDepositsToBoth = (roundId) => {
+          itSettlesAppealDeposits(roundId, () => {
+            it('splits the appeal deposit', async () => {
+              const { accounting, feeToken } = courtHelper
+              const { appealFees, appealDeposit, confirmAppealDeposit } = await courtHelper.getAppealFees(disputeId, roundId)
+
+              const expectedAppealMakerReward = appealDeposit.sub(appealFees.div(bn(2)))
+              const previousAppealMakerBalance = await accounting.balanceOf(feeToken.address, appealMaker)
+
+              const expectedAppealTakerReward = confirmAppealDeposit.sub(appealFees.div(bn(2)))
+              const previousAppealTakerBalance = await accounting.balanceOf(feeToken.address, appealTaker)
+
+              await court.settleAppealDeposit(disputeId, roundId)
+
+              const currentAppealMakerBalance = await accounting.balanceOf(feeToken.address, appealMaker)
+              assert.equal(previousAppealMakerBalance.add(expectedAppealMakerReward).toString(), currentAppealMakerBalance.toString(), 'appeal maker balances do not match')
+
+              const currentAppealTakerBalance = await accounting.balanceOf(feeToken.address, appealTaker)
+              assert.equal(previousAppealTakerBalance.add(expectedAppealTakerReward).toString(), currentAppealTakerBalance.toString(), 'appeal taker balances do not match')
+            })
+          })
+        }
+
+        context('when the round was not appealed', () => {
+          const expectedFinalRuling = OUTCOMES.LOW
+          const expectedWinningJurors = voters.filter(({ outcome }) => outcome === expectedFinalRuling)
+          const expectedLosingJurors = filterJurors(voters, expectedWinningJurors)
+
+          beforeEach('pass appeal and confirmation periods', async () => {
+            await courtHelper.passTerms(courtHelper.appealTerms.add(courtHelper.appealConfirmTerms))
           })
 
-          itIsAtState(roundId, ROUND_STATES.REVEALING)
-          itFailsToExecuteRuling()
-          itFailsToSettleAll(roundId)
+          itIsAtState(roundId, ROUND_STATES.ENDED)
+          itExecutesFinalRulingProperly(expectedFinalRuling)
+          itSettlesPenaltiesAndRewardsProperly(roundId, expectedWinningJurors, expectedLosingJurors)
+          itCannotSettleAppealDeposits(roundId)
         })
 
-        context('during appeal period', () => {
-          beforeEach('commit and reveal votes', async () => {
-            await courtHelper.commit({ disputeId, roundId, voters })
-            await courtHelper.reveal({ disputeId, roundId, voters })
+        context('when the round was appealed', () => {
+          const appealedRuling = OUTCOMES.HIGH
+
+          beforeEach('appeal', async () => {
+            await courtHelper.appeal({ disputeId, roundId, appealMaker, ruling: appealedRuling })
           })
 
-          itIsAtState(roundId, ROUND_STATES.APPEALING)
-          itFailsToExecuteRuling()
-          itFailsToSettleAll(roundId)
-        })
-
-        context('during the appeal confirmation period', () => {
-          beforeEach('commit and reveal votes', async () => {
-            await courtHelper.commit({ disputeId, roundId, voters })
-            await courtHelper.reveal({ disputeId, roundId, voters })
-          })
-
-          context('when the round was not appealed', () => {
-            const expectedFinalRuling = OUTCOMES.LOW
+          context('when the appeal was not confirmed', () => {
+            const expectedFinalRuling = appealedRuling
             const expectedWinningJurors = voters.filter(({ outcome }) => outcome === expectedFinalRuling)
             const expectedLosingJurors = filterJurors(voters, expectedWinningJurors)
 
-            beforeEach('pass appeal period', async () => {
-              await courtHelper.passTerms(courtHelper.appealTerms)
+            beforeEach('pass confirmation period', async () => {
+              await courtHelper.passTerms(courtHelper.appealConfirmTerms)
             })
 
             itIsAtState(roundId, ROUND_STATES.ENDED)
             itExecutesFinalRulingProperly(expectedFinalRuling)
             itSettlesPenaltiesAndRewardsProperly(roundId, expectedWinningJurors, expectedLosingJurors)
-            itCannotSettleAppealDeposits(roundId)
+            itReturnsAppealDepositsToMaker(roundId)
           })
 
-          context('when the round was appealed', () => {
-            beforeEach('appeal', async () => {
-              await courtHelper.appeal({ disputeId, roundId, appealMaker })
+          context('when the appeal was confirmed', () => {
+            beforeEach('confirm appeal', async () => {
+              await courtHelper.confirmAppeal({ disputeId, roundId, appealTaker })
             })
 
-            itIsAtState(roundId, ROUND_STATES.CONFIRMING_APPEAL)
+            itIsAtState(roundId, ROUND_STATES.ENDED)
             itFailsToExecuteRuling()
             itFailsToSettleAll(roundId)
-          })
-        })
 
-        context('after the appeal confirmation period', () => {
-          beforeEach('commit and reveal votes', async () => {
-            await courtHelper.commit({ disputeId, roundId, voters })
-            await courtHelper.reveal({ disputeId, roundId, voters })
-          })
+            context('when the next round is a regular round', () => {
+              const newRoundId = roundId + 1
 
-          const itSettlesAppealDeposits = (roundId, itTransferAppealsDeposits) => {
-            describe('settleAppealDeposit', () => {
-              context('when penalties have been settled', () => {
-                beforeEach('settle penalties', async () => {
-                  await court.settlePenalties(disputeId, roundId, 0)
+              const itHandlesRoundsSettlesProperly = (newRoundVoters, expectedFinalRuling) => {
+                const [firstRoundWinners, firstRoundLosers] = filterWinningJurors(voters, expectedFinalRuling)
+                const [secondRoundWinners, secondRoundLosers] = filterWinningJurors(newRoundVoters, expectedFinalRuling)
+
+                beforeEach('draft and vote second round', async () => {
+                  const expectedNewRoundJurorsNumber = 9 // previous jurors * 3 + 1
+                  const { roundJurorsNumber } = await courtHelper.getRound(disputeId, newRoundId)
+                  assert.equal(roundJurorsNumber.toString(), expectedNewRoundJurorsNumber, 'new round jurors number does not match')
+
+                  await courtHelper.draft({ disputeId, maxJurorsToBeDrafted: expectedNewRoundJurorsNumber, draftedJurors: newRoundVoters })
+                  await courtHelper.commit({ disputeId, roundId: newRoundId, voters: newRoundVoters })
+                  await courtHelper.reveal({ disputeId, roundId: newRoundId, voters: newRoundVoters })
+                  await courtHelper.passTerms(courtHelper.appealTerms.add(courtHelper.appealConfirmTerms))
                 })
 
-                itTransferAppealsDeposits()
+                itExecutesFinalRulingProperly(expectedFinalRuling)
 
-                it('emits an event', async () => {
-                  const receipt = await court.settleAppealDeposit(disputeId, roundId)
-
-                  assertAmountOfEvents(receipt, 'AppealDepositSettled')
-                  assertEvent(receipt, 'AppealDepositSettled', { disputeId, roundId })
+                context('when settling first round', () => {
+                  itSettlesPenaltiesAndRewardsProperly(roundId, firstRoundWinners, firstRoundLosers)
                 })
 
-                it('does not affect the balances of the court', async () => {
-                  const { accounting, feeToken } = courtHelper
-                  const previousCourtBalance = await feeToken.balanceOf(court.address)
-                  const previousAccountingBalance = await feeToken.balanceOf(accounting.address)
-
-                  await court.settleAppealDeposit(disputeId, roundId)
-
-                  const currentCourtBalance = await feeToken.balanceOf(court.address)
-                  assert.equal(previousCourtBalance.toString(), currentCourtBalance.toString(), 'court balances do not match')
-
-                  const currentAccountingBalance = await feeToken.balanceOf(accounting.address)
-                  assert.equal(previousAccountingBalance.toString(), currentAccountingBalance.toString(), 'court accounting balances do not match')
-                })
-
-                it('cannot be settled twice', async () => {
-                  await court.settleAppealDeposit(disputeId, roundId)
-
-                  await assertRevert(court.settleAppealDeposit(disputeId, roundId), 'CT_APPEAL_ALREADY_SETTLED')
-                })
-              })
-
-              context('when penalties have not been settled yet', () => {
-                it('reverts', async () => {
-                  await assertRevert(court.settleAppealDeposit(disputeId, roundId), 'CT_ROUND_PENALTIES_NOT_SETTLED')
-                })
-              })
-            })
-          }
-
-          const itReturnsAppealDepositsToMaker = (roundId) => {
-            itSettlesAppealDeposits(roundId, () => {
-              it('returns the deposit to the appeal maker', async () => {
-                const { accounting, feeToken } = courtHelper
-                const { appealDeposit } = await courtHelper.getAppealFees(disputeId, roundId)
-
-                const previousBalance = await accounting.balanceOf(feeToken.address, appealMaker)
-
-                await court.settleAppealDeposit(disputeId, roundId)
-
-                const currentBalance = await accounting.balanceOf(feeToken.address, appealMaker)
-                assert.equal(previousBalance.add(appealDeposit).toString(), currentBalance.toString(), 'appeal maker balances do not match')
-              })
-            })
-          }
-
-          const itSettlesAppealDepositsToMaker = (roundId) => {
-            itSettlesAppealDeposits(roundId, () => {
-              it('settles the total deposit to the appeal taker', async () => {
-                const { accounting, feeToken } = courtHelper
-                const { appealFees, appealDeposit, confirmAppealDeposit } = await courtHelper.getAppealFees(disputeId, roundId)
-
-                const expectedAppealReward = appealDeposit.add(confirmAppealDeposit).sub(appealFees)
-                const previousAppealTakerBalance = await accounting.balanceOf(feeToken.address, appealTaker)
-
-                await court.settleAppealDeposit(disputeId, roundId)
-
-                const currentAppealTakerBalance = await accounting.balanceOf(feeToken.address, appealTaker)
-                assert.equal(previousAppealTakerBalance.add(expectedAppealReward).toString(), currentAppealTakerBalance.toString(), 'appeal maker balances do not match')
-              })
-            })
-          }
-
-          const itSettlesAppealDepositsToTaker = (roundId) => {
-            itSettlesAppealDeposits(roundId, () => {
-              it('settles the total deposit to the appeal maker', async () => {
-                const { accounting, feeToken } = courtHelper
-                const { appealFees, appealDeposit, confirmAppealDeposit } = await courtHelper.getAppealFees(disputeId, roundId)
-
-                const expectedAppealReward = appealDeposit.add(confirmAppealDeposit).sub(appealFees)
-                const previousAppealMakerBalance = await accounting.balanceOf(feeToken.address, appealMaker)
-
-                await court.settleAppealDeposit(disputeId, roundId)
-
-                const currentAppealMakerBalance = await accounting.balanceOf(feeToken.address, appealMaker)
-                assert.equal(previousAppealMakerBalance.add(expectedAppealReward).toString(), currentAppealMakerBalance.toString(), 'appeal maker balances do not match')
-              })
-            })
-          }
-
-          const itReturnsAppealDepositsToBoth = (roundId) => {
-            itSettlesAppealDeposits(roundId, () => {
-              it('splits the appeal deposit', async () => {
-                const { accounting, feeToken } = courtHelper
-                const { appealFees, appealDeposit, confirmAppealDeposit } = await courtHelper.getAppealFees(disputeId, roundId)
-
-                const expectedAppealMakerReward = appealDeposit.sub(appealFees.div(bn(2)))
-                const previousAppealMakerBalance = await accounting.balanceOf(feeToken.address, appealMaker)
-
-                const expectedAppealTakerReward = confirmAppealDeposit.sub(appealFees.div(bn(2)))
-                const previousAppealTakerBalance = await accounting.balanceOf(feeToken.address, appealTaker)
-
-                await court.settleAppealDeposit(disputeId, roundId)
-
-                const currentAppealMakerBalance = await accounting.balanceOf(feeToken.address, appealMaker)
-                assert.equal(previousAppealMakerBalance.add(expectedAppealMakerReward).toString(), currentAppealMakerBalance.toString(), 'appeal maker balances do not match')
-
-                const currentAppealTakerBalance = await accounting.balanceOf(feeToken.address, appealTaker)
-                assert.equal(previousAppealTakerBalance.add(expectedAppealTakerReward).toString(), currentAppealTakerBalance.toString(), 'appeal taker balances do not match')
-              })
-            })
-          }
-
-          context('when the round was not appealed', () => {
-            const expectedFinalRuling = OUTCOMES.LOW
-            const expectedWinningJurors = voters.filter(({ outcome }) => outcome === expectedFinalRuling)
-            const expectedLosingJurors = filterJurors(voters, expectedWinningJurors)
-
-            beforeEach('pass appeal and confirmation periods', async () => {
-              await courtHelper.passTerms(courtHelper.appealTerms.add(courtHelper.appealConfirmTerms))
-            })
-
-            itIsAtState(roundId, ROUND_STATES.ENDED)
-            itExecutesFinalRulingProperly(expectedFinalRuling)
-            itSettlesPenaltiesAndRewardsProperly(roundId, expectedWinningJurors, expectedLosingJurors)
-            itCannotSettleAppealDeposits(roundId)
-          })
-
-          context('when the round was appealed', () => {
-            const appealedRuling = OUTCOMES.HIGH
-
-            beforeEach('appeal', async () => {
-              await courtHelper.appeal({ disputeId, roundId, appealMaker, ruling: appealedRuling })
-            })
-
-            context('when the appeal was not confirmed', () => {
-              const expectedFinalRuling = appealedRuling
-              const expectedWinningJurors = voters.filter(({ outcome }) => outcome === expectedFinalRuling)
-              const expectedLosingJurors = filterJurors(voters, expectedWinningJurors)
-
-              beforeEach('pass confirmation period', async () => {
-                await courtHelper.passTerms(courtHelper.appealConfirmTerms)
-              })
-
-              itIsAtState(roundId, ROUND_STATES.ENDED)
-              itExecutesFinalRulingProperly(expectedFinalRuling)
-              itSettlesPenaltiesAndRewardsProperly(roundId, expectedWinningJurors, expectedLosingJurors)
-              itReturnsAppealDepositsToMaker(roundId)
-            })
-
-            context('when the appeal was confirmed', () => {
-              beforeEach('confirm appeal', async () => {
-                await courtHelper.confirmAppeal({ disputeId, roundId, appealTaker })
-              })
-
-              itIsAtState(roundId, ROUND_STATES.ENDED)
-              itFailsToExecuteRuling()
-              itFailsToSettleAll(roundId)
-
-              context('when the next round is a regular round', () => {
-                const newRoundId = roundId + 1
-
-                const itHandlesRoundsSettlesProperly = (newRoundVoters, expectedFinalRuling) => {
-                  const [firstRoundWinners, firstRoundLosers] = filterWinningJurors(voters, expectedFinalRuling)
-                  const [secondRoundWinners, secondRoundLosers] = filterWinningJurors(newRoundVoters, expectedFinalRuling)
-
-                  beforeEach('draft and vote second round', async () => {
-                    const expectedNewRoundJurorsNumber = 9 // previous jurors * 3 + 1
-                    const { roundJurorsNumber } = await courtHelper.getRound(disputeId, newRoundId)
-                    assert.equal(roundJurorsNumber.toString(), expectedNewRoundJurorsNumber, 'new round jurors number does not match')
-
-                    await courtHelper.draft({ disputeId, maxJurorsToBeDrafted: expectedNewRoundJurorsNumber, draftedJurors: newRoundVoters })
-                    await courtHelper.commit({ disputeId, roundId: newRoundId, voters: newRoundVoters })
-                    await courtHelper.reveal({ disputeId, roundId: newRoundId, voters: newRoundVoters })
-                    await courtHelper.passTerms(courtHelper.appealTerms.add(courtHelper.appealConfirmTerms))
-                  })
-
-                  itExecutesFinalRulingProperly(expectedFinalRuling)
-
-                  context('when settling first round', () => {
-                    itSettlesPenaltiesAndRewardsProperly(roundId, firstRoundWinners, firstRoundLosers)
-                  })
-
-                  context('when settling second round', () => {
-                    beforeEach('settle first round', async () => {
-                      await court.settlePenalties(disputeId, roundId, 0)
-                      for (const { address } of firstRoundWinners) {
-                        await court.settleReward(disputeId, roundId, address)
-                      }
-                    })
-
-                    itSettlesPenaltiesAndRewardsProperly(newRoundId, secondRoundWinners, secondRoundLosers)
-                  })
-                }
-
-                context('when the ruling is sustained', async () => {
-                  const expectedFinalRuling = OUTCOMES.LOW
-                  const newRoundVoters = [
-                    { address: juror500,  weight: 1, outcome: OUTCOMES.HIGH },
-                    { address: juror2000, weight: 4, outcome: OUTCOMES.LOW },
-                    { address: juror2500, weight: 1, outcome: OUTCOMES.HIGH },
-                    { address: juror4000, weight: 2, outcome: OUTCOMES.LOW },
-                    { address: juror3000, weight: 1, outcome: OUTCOMES.LOW },
-                  ]
-
-                  itHandlesRoundsSettlesProperly(newRoundVoters, expectedFinalRuling)
-                  itSettlesAppealDepositsToMaker(roundId)
-                })
-
-                context('when the ruling is flipped', async () => {
-                  const expectedFinalRuling = appealedRuling
-                  const newRoundVoters = [
-                    { address: juror500,  weight: 1, outcome: OUTCOMES.HIGH },
-                    { address: juror2000, weight: 4, outcome: OUTCOMES.HIGH },
-                    { address: juror2500, weight: 1, outcome: OUTCOMES.HIGH },
-                    { address: juror4000, weight: 2, outcome: OUTCOMES.HIGH },
-                    { address: juror3000, weight: 1, outcome: OUTCOMES.HIGH },
-                  ]
-
-                  itHandlesRoundsSettlesProperly(newRoundVoters, expectedFinalRuling)
-                  itSettlesAppealDepositsToTaker(roundId)
-                })
-
-                context('when the ruling is refused', async () => {
-                  const expectedFinalRuling = OUTCOMES.REFUSED
-                  const newRoundVoters = [
-                    { address: juror500,  weight: 1, outcome: OUTCOMES.REFUSED },
-                    { address: juror2000, weight: 4, outcome: OUTCOMES.REFUSED },
-                    { address: juror2500, weight: 1, outcome: OUTCOMES.REFUSED },
-                    { address: juror4000, weight: 2, outcome: OUTCOMES.REFUSED },
-                    { address: juror3000, weight: 1, outcome: OUTCOMES.REFUSED },
-                  ]
-
-                  itHandlesRoundsSettlesProperly(newRoundVoters, expectedFinalRuling)
-                  itReturnsAppealDepositsToBoth(roundId)
-                })
-              })
-
-              context('when the next round is a final round', () => {
-                const finalRoundId = DEFAULTS.maxRegularAppealRounds.toNumber()
-
-                const itHandlesRoundsSettlesProperly = (finalRoundVoters, expectedFinalRuling) => {
-                  const previousRoundsVoters = { [roundId]: voters }
-                  const [expectedWinners, expectedLosers] = filterWinningJurors(finalRoundVoters, expectedFinalRuling)
-
-                  beforeEach('move to final round', async () => {
-                    // appeal until we reach the final round, always flipping the previous round winning ruling
-                    let previousWinningRuling = await voting.getWinningOutcome(voteId)
-                    for (let nextRoundId = roundId + 1; nextRoundId < finalRoundId; nextRoundId++) {
-                      const roundWinningRuling = oppositeOutcome(previousWinningRuling)
-                      const roundVoters = await courtHelper.draft({ disputeId })
-                      roundVoters.forEach(voter => voter.outcome = roundWinningRuling)
-                      previousRoundsVoters[nextRoundId] = roundVoters
-
-                      await courtHelper.commit({ disputeId, roundId: nextRoundId, voters: roundVoters })
-                      await courtHelper.reveal({ disputeId, roundId: nextRoundId, voters: roundVoters })
-                      await courtHelper.appeal({ disputeId, roundId: nextRoundId, appealMaker, ruling: previousWinningRuling })
-                      await courtHelper.confirmAppeal({ disputeId, roundId: nextRoundId, appealTaker, ruling: roundWinningRuling })
-                      previousWinningRuling = roundWinningRuling
+                context('when settling second round', () => {
+                  beforeEach('settle first round', async () => {
+                    await court.settlePenalties(disputeId, roundId, 0)
+                    for (const { address } of firstRoundWinners) {
+                      await court.settleReward(disputeId, roundId, address)
                     }
                   })
 
-                  beforeEach('end final round', async () => {
-                    // commit and reveal votes, and pass appeal and confirmation periods to end dispute
-                    await courtHelper.commit({ disputeId, roundId: finalRoundId, voters: finalRoundVoters })
-                    await courtHelper.reveal({ disputeId, roundId: finalRoundId, voters: finalRoundVoters })
-                    await courtHelper.passTerms(courtHelper.appealTerms.add(courtHelper.appealConfirmTerms))
-                  })
+                  itSettlesPenaltiesAndRewardsProperly(newRoundId, secondRoundWinners, secondRoundLosers)
+                })
+              }
 
-                  beforeEach('settle previous rounds', async () => {
-                    for (let nextRoundId = 0; nextRoundId < finalRoundId; nextRoundId++) {
-                      await court.settlePenalties(disputeId, nextRoundId, 0)
-                      const [winners] = filterWinningJurors(previousRoundsVoters[nextRoundId], expectedFinalRuling)
-                      for (const { address } of winners) {
-                        await court.settleReward(disputeId, nextRoundId, address)
-                      }
+              context('when the ruling is sustained', async () => {
+                const expectedFinalRuling = OUTCOMES.LOW
+                const newRoundVoters = [
+                  { address: juror500,  weight: 1, outcome: OUTCOMES.HIGH },
+                  { address: juror2000, weight: 4, outcome: OUTCOMES.LOW },
+                  { address: juror2500, weight: 1, outcome: OUTCOMES.HIGH },
+                  { address: juror4000, weight: 2, outcome: OUTCOMES.LOW },
+                  { address: juror3000, weight: 1, outcome: OUTCOMES.LOW },
+                ]
+
+                itHandlesRoundsSettlesProperly(newRoundVoters, expectedFinalRuling)
+                itSettlesAppealDepositsToMaker(roundId)
+              })
+
+              context('when the ruling is flipped', async () => {
+                const expectedFinalRuling = appealedRuling
+                const newRoundVoters = [
+                  { address: juror500,  weight: 1, outcome: OUTCOMES.HIGH },
+                  { address: juror2000, weight: 4, outcome: OUTCOMES.HIGH },
+                  { address: juror2500, weight: 1, outcome: OUTCOMES.HIGH },
+                  { address: juror4000, weight: 2, outcome: OUTCOMES.HIGH },
+                  { address: juror3000, weight: 1, outcome: OUTCOMES.HIGH },
+                ]
+
+                itHandlesRoundsSettlesProperly(newRoundVoters, expectedFinalRuling)
+                itSettlesAppealDepositsToTaker(roundId)
+              })
+
+              context('when the ruling is refused', async () => {
+                const expectedFinalRuling = OUTCOMES.REFUSED
+                const newRoundVoters = [
+                  { address: juror500,  weight: 1, outcome: OUTCOMES.REFUSED },
+                  { address: juror2000, weight: 4, outcome: OUTCOMES.REFUSED },
+                  { address: juror2500, weight: 1, outcome: OUTCOMES.REFUSED },
+                  { address: juror4000, weight: 2, outcome: OUTCOMES.REFUSED },
+                  { address: juror3000, weight: 1, outcome: OUTCOMES.REFUSED },
+                ]
+
+                itHandlesRoundsSettlesProperly(newRoundVoters, expectedFinalRuling)
+                itReturnsAppealDepositsToBoth(roundId)
+              })
+            })
+
+            context('when the next round is a final round', () => {
+              const finalRoundId = DEFAULTS.maxRegularAppealRounds.toNumber()
+
+              const itHandlesRoundsSettlesProperly = (finalRoundVoters, expectedFinalRuling) => {
+                const previousRoundsVoters = { [roundId]: voters }
+                const [expectedWinners, expectedLosers] = filterWinningJurors(finalRoundVoters, expectedFinalRuling)
+
+                beforeEach('move to final round', async () => {
+                  // appeal until we reach the final round, always flipping the previous round winning ruling
+                  let previousWinningRuling = await voting.getWinningOutcome(voteId)
+                  for (let nextRoundId = roundId + 1; nextRoundId < finalRoundId; nextRoundId++) {
+                    const roundWinningRuling = oppositeOutcome(previousWinningRuling)
+                    const roundVoters = await courtHelper.draft({ disputeId })
+                    roundVoters.forEach(voter => voter.outcome = roundWinningRuling)
+                    previousRoundsVoters[nextRoundId] = roundVoters
+
+                    await courtHelper.commit({ disputeId, roundId: nextRoundId, voters: roundVoters })
+                    await courtHelper.reveal({ disputeId, roundId: nextRoundId, voters: roundVoters })
+                    await courtHelper.appeal({ disputeId, roundId: nextRoundId, appealMaker, ruling: previousWinningRuling })
+                    await courtHelper.confirmAppeal({ disputeId, roundId: nextRoundId, appealTaker, ruling: roundWinningRuling })
+                    previousWinningRuling = roundWinningRuling
+                  }
+                })
+
+                beforeEach('end final round', async () => {
+                  // commit and reveal votes, and pass appeal and confirmation periods to end dispute
+                  await courtHelper.commit({ disputeId, roundId: finalRoundId, voters: finalRoundVoters })
+                  await courtHelper.reveal({ disputeId, roundId: finalRoundId, voters: finalRoundVoters })
+                  await courtHelper.passTerms(courtHelper.appealTerms.add(courtHelper.appealConfirmTerms))
+                })
+
+                beforeEach('settle previous rounds', async () => {
+                  for (let nextRoundId = 0; nextRoundId < finalRoundId; nextRoundId++) {
+                    await court.settlePenalties(disputeId, nextRoundId, 0)
+                    const [winners] = filterWinningJurors(previousRoundsVoters[nextRoundId], expectedFinalRuling)
+                    for (const { address } of winners) {
+                      await court.settleReward(disputeId, nextRoundId, address)
                     }
-                  })
-
-                  itExecutesFinalRulingProperly(expectedFinalRuling)
-                  itSettlesPenaltiesAndRewardsProperly(finalRoundId, expectedWinners, expectedLosers)
-                  itCannotSettleAppealDeposits(finalRoundId)
-                }
-
-                context('when the ruling is sustained', async () => {
-                  const expectedFinalRuling = OUTCOMES.LOW
-                  const finalRoundVoters = [
-                    { address: juror500,  outcome: OUTCOMES.HIGH },
-                    { address: juror2000, outcome: OUTCOMES.LOW },
-                    { address: juror2500, outcome: OUTCOMES.HIGH },
-                    { address: juror4000, outcome: OUTCOMES.LOW },
-                    { address: juror3000, outcome: OUTCOMES.LOW },
-                  ]
-
-                  itHandlesRoundsSettlesProperly(finalRoundVoters, expectedFinalRuling)
+                  }
                 })
 
-                context('when the ruling is flipped', async () => {
-                  const expectedFinalRuling = appealedRuling
-                  const finalRoundVoters = [
-                    { address: juror500,  outcome: OUTCOMES.HIGH },
-                    { address: juror2000, outcome: OUTCOMES.HIGH },
-                    { address: juror2500, outcome: OUTCOMES.HIGH },
-                    { address: juror4000, outcome: OUTCOMES.HIGH },
-                    { address: juror3000, outcome: OUTCOMES.HIGH },
-                  ]
+                itExecutesFinalRulingProperly(expectedFinalRuling)
+                itSettlesPenaltiesAndRewardsProperly(finalRoundId, expectedWinners, expectedLosers)
+                itCannotSettleAppealDeposits(finalRoundId)
+              }
 
-                  itHandlesRoundsSettlesProperly(finalRoundVoters, expectedFinalRuling)
-                })
+              context('when the ruling is sustained', async () => {
+                const expectedFinalRuling = OUTCOMES.LOW
+                const finalRoundVoters = [
+                  { address: juror500,  outcome: OUTCOMES.HIGH },
+                  { address: juror2000, outcome: OUTCOMES.LOW },
+                  { address: juror2500, outcome: OUTCOMES.HIGH },
+                  { address: juror4000, outcome: OUTCOMES.LOW },
+                  { address: juror3000, outcome: OUTCOMES.LOW },
+                ]
 
-                context('when the ruling is refused', async () => {
-                  const expectedFinalRuling = OUTCOMES.REFUSED
-                  const finalRoundVoters = [
-                    { address: juror500,  outcome: OUTCOMES.REFUSED },
-                    { address: juror2000, outcome: OUTCOMES.REFUSED },
-                    { address: juror2500, outcome: OUTCOMES.REFUSED },
-                    { address: juror4000, outcome: OUTCOMES.REFUSED },
-                    { address: juror3000, outcome: OUTCOMES.REFUSED },
-                  ]
+                itHandlesRoundsSettlesProperly(finalRoundVoters, expectedFinalRuling)
+              })
 
-                  itHandlesRoundsSettlesProperly(finalRoundVoters, expectedFinalRuling)
-                })
+              context('when the ruling is flipped', async () => {
+                const expectedFinalRuling = appealedRuling
+                const finalRoundVoters = [
+                  { address: juror500,  outcome: OUTCOMES.HIGH },
+                  { address: juror2000, outcome: OUTCOMES.HIGH },
+                  { address: juror2500, outcome: OUTCOMES.HIGH },
+                  { address: juror4000, outcome: OUTCOMES.HIGH },
+                  { address: juror3000, outcome: OUTCOMES.HIGH },
+                ]
+
+                itHandlesRoundsSettlesProperly(finalRoundVoters, expectedFinalRuling)
+              })
+
+              context('when the ruling is refused', async () => {
+                const expectedFinalRuling = OUTCOMES.REFUSED
+                const finalRoundVoters = [
+                  { address: juror500,  outcome: OUTCOMES.REFUSED },
+                  { address: juror2000, outcome: OUTCOMES.REFUSED },
+                  { address: juror2500, outcome: OUTCOMES.REFUSED },
+                  { address: juror4000, outcome: OUTCOMES.REFUSED },
+                  { address: juror3000, outcome: OUTCOMES.REFUSED },
+                ]
+
+                itHandlesRoundsSettlesProperly(finalRoundVoters, expectedFinalRuling)
               })
             })
           })
-        })
-      })
-
-      // TODO: this scenario is not implemented in the contracts yet
-      context.skip('when the given round is not valid', () => {
-        const roundId = 5
-
-        it('reverts', async () => {
-          await assertRevert(court.createAppeal(disputeId, roundId, OUTCOMES.LOW), 'CT_ROUND_DOES_NOT_EXIST')
         })
       })
     })
 
     // TODO: this scenario is not implemented in the contracts yet
-    context.skip('when the given dispute does not exist', () => {
+    context.skip('when the given round is not valid', () => {
+      const roundId = 5
+
       it('reverts', async () => {
-        await assertRevert(court.createAppeal(0, 0, OUTCOMES.LOW), 'CT_DISPUTE_DOES_NOT_EXIST')
+        await assertRevert(court.createAppeal(disputeId, roundId, OUTCOMES.LOW), 'CT_ROUND_DOES_NOT_EXIST')
       })
+    })
+  })
+
+  // TODO: this scenario is not implemented in the contracts yet
+  context.skip('when the given dispute does not exist', () => {
+    it('reverts', async () => {
+      await assertRevert(court.createAppeal(0, 0, OUTCOMES.LOW), 'CT_DISPUTE_DOES_NOT_EXIST')
     })
   })
 })

--- a/test/court/court-terms.js
+++ b/test/court/court-terms.js
@@ -6,7 +6,7 @@ const { assertAmountOfEvents, assertEvent } = require('../helpers/assertEvent')
 
 const ERC20 = artifacts.require('ERC20Mock')
 
-contract('Court', ([_, sender]) => {
+contract('Court (terms)', ([_, sender]) => {
   let courtHelper, court
 
 const EMPTY_RANDOMNESS = '0x0000000000000000000000000000000000000000000000000000000000000000'

--- a/test/court/court-voting.js
+++ b/test/court/court-voting.js
@@ -5,7 +5,7 @@ const { buildHelper, DEFAULTS, ROUND_STATES } = require('../helpers/court')(web3
 const { assertAmountOfEvents, assertEvent } = require('../helpers/assertEvent')
 const { getVoteId, encryptVote, outcomeFor, SALT, OUTCOMES } = require('../helpers/crvoting')
 
-contract('Court', ([_, disputer, drafter, juror100, juror500, juror1000, juror1500, juror2000, juror2500, juror3000, juror3500, juror4000]) => {
+contract('Court (voting)', ([_, disputer, drafter, juror100, juror500, juror1000, juror1500, juror2000, juror2500, juror3000, juror3500, juror4000]) => {
   let courtHelper, court, voting
 
   const jurors = [
@@ -26,279 +26,91 @@ contract('Court', ([_, disputer, drafter, juror100, juror500, juror1000, juror15
     voting = courtHelper.voting
   })
 
-  describe('voting', () => {
-    const draftTermId = 4
-    let disputeId, voteId, voters, nonVoters
+  const draftTermId = 4
+  let disputeId, voteId, voters, nonVoters
 
-    beforeEach('activate jurors and create dispute', async () => {
-      await courtHelper.activate(jurors)
+  beforeEach('activate jurors and create dispute', async () => {
+    await courtHelper.activate(jurors)
 
-      await courtHelper.setTerm(1)
-      disputeId = await courtHelper.dispute({ draftTermId, disputer })
-      await courtHelper.passTerms(bn(draftTermId - 1)) // court is already at term one
+    await courtHelper.setTerm(1)
+    disputeId = await courtHelper.dispute({ draftTermId, disputer })
+    await courtHelper.passTerms(bn(draftTermId - 1)) // court is already at term one
+  })
+
+  const itIsAtState = (roundId, state) => {
+    it(`round is at state ${state}`, async () => {
+      const { roundState } = await courtHelper.getRound(disputeId, roundId)
+      assert.equal(roundState.toString(), state.toString(), 'round state does not match')
+    })
+  }
+
+  const itFailsToCommitVotes = () => {
+    it('fails to commit votes', async () => {
+      for (const { address } of jurors) {
+        await assertRevert(voting.commit(voteId, encryptVote(OUTCOMES.LOW), { from: address }), 'CT_INVALID_ADJUDICATION_STATE')
+      }
+    })
+  }
+
+  const itFailsToRevealVotes = () => {
+    it('fails to reveal votes', async () => {
+      for (const { outcome, address } of voters) {
+        await assertRevert(voting.reveal(voteId, outcome, SALT, { from: address }), 'CT_INVALID_ADJUDICATION_STATE')
+      }
+    })
+  }
+
+  context('for regular rounds', () => {
+    const roundId = 0
+    let draftedJurors, nonDraftedJurors
+
+    beforeEach('draft round', async () => {
+      draftedJurors = await courtHelper.draft({ disputeId, drafter })
+      nonDraftedJurors = filterJurors(jurors, draftedJurors)
     })
 
-    const itIsAtState = (roundId, state) => {
-      it(`round is at state ${state}`, async () => {
-        const { roundState } = await courtHelper.getRound(disputeId, roundId)
-        assert.equal(roundState.toString(), state.toString(), 'round state does not match')
-      })
-    }
+    beforeEach('define a group of voters', async () => {
+      voteId = getVoteId(disputeId, roundId)
+      // pick the first 3 drafted jurors to vote
+      voters = draftedJurors.slice(0, 3)
+      voters.forEach((voter, i) => voter.outcome = outcomeFor(i))
+      nonVoters = filterJurors(draftedJurors, voters)
+    })
 
-    const itFailsToCommitVotes = () => {
-      it('fails to commit votes', async () => {
-        for (const { address } of jurors) {
-          await assertRevert(voting.commit(voteId, encryptVote(OUTCOMES.LOW), { from: address }), 'CT_INVALID_ADJUDICATION_STATE')
-        }
-      })
-    }
+    context('during commit period', () => {
+      const outcome = OUTCOMES.LOW
+      const vote = encryptVote(outcome)
 
-    const itFailsToRevealVotes = () => {
-      it('fails to reveal votes', async () => {
-        for (const { outcome, address } of voters) {
-          await assertRevert(voting.reveal(voteId, outcome, SALT, { from: address }), 'CT_INVALID_ADJUDICATION_STATE')
-        }
-      })
-    }
+      itIsAtState(roundId, ROUND_STATES.COMMITTING)
+      itFailsToRevealVotes()
 
-    context('for regular rounds', () => {
-      const roundId = 0
-      let draftedJurors, nonDraftedJurors
-
-      beforeEach('draft round', async () => {
-        draftedJurors = await courtHelper.draft({ disputeId, drafter })
-        nonDraftedJurors = filterJurors(jurors, draftedJurors)
-      })
-
-      beforeEach('define a group of voters', async () => {
-        voteId = getVoteId(disputeId, roundId)
-        // pick the first 3 drafted jurors to vote
-        voters = draftedJurors.slice(0, 3)
-        voters.forEach((voter, i) => voter.outcome = outcomeFor(i))
-        nonVoters = filterJurors(draftedJurors, voters)
-      })
-
-      context('during commit period', () => {
-        const outcome = OUTCOMES.LOW
-        const vote = encryptVote(outcome)
-
-        itIsAtState(roundId, ROUND_STATES.COMMITTING)
-        itFailsToRevealVotes()
-
-        context('when the sender was drafted', () => {
-          it('allows to commit a vote', async () => {
-            for (const { address } of draftedJurors) {
-              const receipt = await voting.commit(voteId, vote, { from: address })
-              assertAmountOfEvents(receipt, 'VoteCommitted')
-            }
-          })
-        })
-
-        context('when the sender was not drafted', () => {
-          it('reverts', async () => {
-            for (const { address } of nonDraftedJurors) {
-              await assertRevert(voting.commit(voteId, vote, { from: address }), 'CRV_COMMIT_DENIED_BY_OWNER')
-            }
-          })
+      context('when the sender was drafted', () => {
+        it('allows to commit a vote', async () => {
+          for (const { address } of draftedJurors) {
+            const receipt = await voting.commit(voteId, vote, { from: address })
+            assertAmountOfEvents(receipt, 'VoteCommitted')
+          }
         })
       })
 
-      context('during reveal period', () => {
-        beforeEach('commit votes', async () => {
-          await courtHelper.commit({ disputeId, roundId, voters })
-        })
-
-        itIsAtState(roundId, ROUND_STATES.REVEALING)
-        itFailsToCommitVotes()
-
-        context('when the sender was drafted', () => {
-          context('when the sender voted', () => {
-            let receipts, expectedTally
-
-            beforeEach('reveal votes', async () => {
-              receipts = []
-              expectedTally = { [OUTCOMES.LOW]: 0, [OUTCOMES.HIGH]: 0 }
-
-              for (const { address, weight, outcome } of voters) {
-                expectedTally[outcome] += weight.toNumber()
-                receipts.push(await voting.reveal(voteId, outcome, SALT, { from: address }))
-              }
-            })
-
-            it('allows voters to reveal their vote', async () => {
-              for (let i = 0; i < voters.length; i++) {
-                const { address, outcome } = voters[i]
-                assertEvent(receipts[i], 'VoteRevealed', { voteId, voter: address, outcome })
-              }
-            })
-
-            it('computes tallies properly', async () => {
-              const lowOutcomeTally = await voting.getOutcomeTally(voteId, OUTCOMES.LOW)
-              assert.equal(lowOutcomeTally.toString(), expectedTally[OUTCOMES.LOW], 'low outcome tally does not match')
-
-              const highOutcomeTally = await voting.getOutcomeTally(voteId, OUTCOMES.HIGH)
-              assert.equal(highOutcomeTally.toString(), expectedTally[OUTCOMES.HIGH], 'high outcome tally does not match')
-
-              const winningOutcome = await voting.getWinningOutcome(voteId)
-              const expectedWinningOutcome = highOutcomeTally > lowOutcomeTally ? OUTCOMES.HIGH : OUTCOMES.LOW
-              assert.equal(winningOutcome.toString(), expectedWinningOutcome, 'winning outcome does not match')
-            })
-          })
-
-          context('when the sender did not vote', () => {
-            it('reverts', async () => {
-              for (const { address } of nonVoters) {
-                await assertRevert(voting.reveal(voteId, OUTCOMES.LOW, SALT, { from: address }), 'CRV_INVALID_COMMITMENT_SALT')
-              }
-            })
-          })
-        })
-
-        context('when the sender was not drafted', () => {
-          it('disallows every non-voter to reveal votes', async () => {
-            for (const { address } of nonDraftedJurors) {
-              await assertRevert(voting.reveal(voteId, OUTCOMES.LOW, SALT, { from: address }), 'CRV_REVEAL_DENIED_BY_OWNER')
-            }
-          })
-        })
-      })
-
-      context('during appeal period', () => {
-        beforeEach('commit and reveal votes', async () => {
-          await courtHelper.commit({ disputeId, roundId, voters })
-          await courtHelper.reveal({ disputeId, roundId, voters })
-        })
-
-        itIsAtState(roundId, ROUND_STATES.APPEALING)
-        itFailsToCommitVotes()
-        itFailsToRevealVotes()
-      })
-
-      context('during the appeal confirmation period', () => {
-        beforeEach('commit and reveal votes', async () => {
-          await courtHelper.commit({ disputeId, roundId, voters })
-          await courtHelper.reveal({ disputeId, roundId, voters })
-        })
-
-        context('when the round was not appealed', () => {
-          beforeEach('pass appeal period', async () => {
-            await courtHelper.passTerms(courtHelper.appealTerms)
-          })
-
-          itIsAtState(roundId, ROUND_STATES.ENDED)
-          itFailsToCommitVotes()
-          itFailsToRevealVotes()
-        })
-
-        context('when the round was appealed', () => {
-          beforeEach('appeal', async () => {
-            await courtHelper.appeal({ disputeId, roundId })
-          })
-
-          itIsAtState(roundId, ROUND_STATES.CONFIRMING_APPEAL)
-          itFailsToCommitVotes()
-          itFailsToRevealVotes()
-        })
-      })
-
-      context('after the appeal confirmation period', () => {
-        beforeEach('commit and reveal votes', async () => {
-          await courtHelper.commit({ disputeId, roundId, voters })
-          await courtHelper.reveal({ disputeId, roundId, voters })
-        })
-
-        context('when the round was not appealed', () => {
-          beforeEach('pass appeal and confirmation periods', async () => {
-            await courtHelper.passTerms(courtHelper.appealTerms.add(courtHelper.appealConfirmTerms))
-          })
-
-          itIsAtState(roundId, ROUND_STATES.ENDED)
-          itFailsToCommitVotes()
-          itFailsToRevealVotes()
-        })
-
-        context('when the round was appealed', () => {
-          beforeEach('appeal', async () => {
-            await courtHelper.appeal({ disputeId, roundId })
-          })
-
-          context('when the appeal was not confirmed', () => {
-            beforeEach('pass appeal confirmation period', async () => {
-              await courtHelper.passTerms(courtHelper.appealConfirmTerms)
-            })
-
-            itIsAtState(roundId, ROUND_STATES.ENDED)
-            itFailsToCommitVotes()
-            itFailsToRevealVotes()
-          })
-
-          context('when the appeal was confirmed', () => {
-            beforeEach('confirm appeal', async () => {
-              await courtHelper.confirmAppeal({ disputeId, roundId })
-            })
-
-            itIsAtState(roundId, ROUND_STATES.ENDED)
-            itFailsToCommitVotes()
-            itFailsToRevealVotes()
-          })
+      context('when the sender was not drafted', () => {
+        it('reverts', async () => {
+          for (const { address } of nonDraftedJurors) {
+            await assertRevert(voting.commit(voteId, vote, { from: address }), 'CRV_COMMIT_DENIED_BY_OWNER')
+          }
         })
       })
     })
 
-    context('for a final round', () => {
-      const roundId = DEFAULTS.maxRegularAppealRounds.toNumber(), poorJuror = juror100
-
-      beforeEach('simulate juror without enough balance to vote on a final round', async () => {
-        await court.collect(poorJuror, bigExp(99, 18))
-        await courtHelper.passTerms(bn(1))
-
-        const { active } = await courtHelper.jurorsRegistry.balanceOf(poorJuror)
-        assert.equal(active.toString(), bigExp(1, 18).toString(), 'poor juror active balance does not match')
+    context('during reveal period', () => {
+      beforeEach('commit votes', async () => {
+        await courtHelper.commit({ disputeId, roundId, voters })
       })
 
-      beforeEach('move to final round', async () => {
-        await courtHelper.moveToFinalRound({ disputeId })
-      })
+      itIsAtState(roundId, ROUND_STATES.REVEALING)
+      itFailsToCommitVotes()
 
-      beforeEach('define a group of voters', async () => {
-        voteId = getVoteId(disputeId, roundId)
-        voters = [
-          { address: juror1000, outcome: OUTCOMES.LOW },
-          { address: juror4000, outcome: OUTCOMES.LOW },
-          { address: juror2000, outcome: OUTCOMES.HIGH },
-          { address: juror1500, outcome: OUTCOMES.REFUSED },
-        ]
-        nonVoters = filterJurors(jurors, voters)
-      })
-
-      context('during commit period', () => {
-        itIsAtState(roundId, ROUND_STATES.COMMITTING)
-        itFailsToRevealVotes()
-
-        context('when the sender has enough active balance', () => {
-          it('allows to commit a vote', async () => {
-            for (const { address, outcome } of voters) {
-              const receipt = await voting.commit(voteId, encryptVote(outcome), { from: address })
-              assertAmountOfEvents(receipt, 'VoteCommitted')
-            }
-          })
-        })
-
-        context('when the sender does not have enough active balance', () => {
-          it('reverts', async () => {
-            await assertRevert(voting.commit(voteId, encryptVote(OUTCOMES.LOW), { from: poorJuror }), 'CRV_COMMIT_DENIED_BY_OWNER')
-          })
-        })
-      })
-
-      context('during reveal period', () => {
-        beforeEach('commit votes', async () => {
-          await courtHelper.commit({ disputeId, roundId, voters })
-        })
-
-        itIsAtState(roundId, ROUND_STATES.REVEALING)
-        itFailsToCommitVotes()
-
+      context('when the sender was drafted', () => {
         context('when the sender voted', () => {
           let receipts, expectedTally
 
@@ -306,8 +118,7 @@ contract('Court', ([_, disputer, drafter, juror100, juror500, juror1000, juror15
             receipts = []
             expectedTally = { [OUTCOMES.LOW]: 0, [OUTCOMES.HIGH]: 0 }
 
-            for (const { address, outcome } of voters) {
-              const { weight } = await courtHelper.getRoundJuror(disputeId, roundId, address)
+            for (const { address, weight, outcome } of voters) {
               expectedTally[outcome] += weight.toNumber()
               receipts.push(await voting.reveal(voteId, outcome, SALT, { from: address }))
             }
@@ -336,28 +147,40 @@ contract('Court', ([_, disputer, drafter, juror100, juror500, juror1000, juror15
         context('when the sender did not vote', () => {
           it('reverts', async () => {
             for (const { address } of nonVoters) {
-              const expectedReason = address === poorJuror ? 'CRV_REVEAL_DENIED_BY_OWNER' : 'CRV_INVALID_COMMITMENT_SALT'
-              await assertRevert(voting.reveal(voteId, OUTCOMES.LOW, SALT, { from: address }), expectedReason)
+              await assertRevert(voting.reveal(voteId, OUTCOMES.LOW, SALT, { from: address }), 'CRV_INVALID_COMMITMENT_SALT')
             }
           })
         })
       })
 
-      context('during appeal period', () => {
-        beforeEach('commit and reveal votes', async () => {
-          await courtHelper.commit({ disputeId, roundId, voters })
-          await courtHelper.reveal({ disputeId, roundId, voters })
+      context('when the sender was not drafted', () => {
+        it('disallows every non-voter to reveal votes', async () => {
+          for (const { address } of nonDraftedJurors) {
+            await assertRevert(voting.reveal(voteId, OUTCOMES.LOW, SALT, { from: address }), 'CRV_REVEAL_DENIED_BY_OWNER')
+          }
         })
+      })
+    })
 
-        itIsAtState(roundId, ROUND_STATES.ENDED)
-        itFailsToCommitVotes()
-        itFailsToRevealVotes()
+    context('during appeal period', () => {
+      beforeEach('commit and reveal votes', async () => {
+        await courtHelper.commit({ disputeId, roundId, voters })
+        await courtHelper.reveal({ disputeId, roundId, voters })
       })
 
-      context('during the appeal confirmation period', () => {
-        beforeEach('commit and reveal votes, and pass appeal period', async () => {
-          await courtHelper.commit({ disputeId, roundId, voters })
-          await courtHelper.reveal({ disputeId, roundId, voters })
+      itIsAtState(roundId, ROUND_STATES.APPEALING)
+      itFailsToCommitVotes()
+      itFailsToRevealVotes()
+    })
+
+    context('during the appeal confirmation period', () => {
+      beforeEach('commit and reveal votes', async () => {
+        await courtHelper.commit({ disputeId, roundId, voters })
+        await courtHelper.reveal({ disputeId, roundId, voters })
+      })
+
+      context('when the round was not appealed', () => {
+        beforeEach('pass appeal period', async () => {
           await courtHelper.passTerms(courtHelper.appealTerms)
         })
 
@@ -366,10 +189,25 @@ contract('Court', ([_, disputer, drafter, juror100, juror500, juror1000, juror15
         itFailsToRevealVotes()
       })
 
-      context('after the appeal confirmation period', () => {
-        beforeEach('commit and reveal votes, and pass appeal and confirmation periods', async () => {
-          await courtHelper.commit({ disputeId, roundId, voters })
-          await courtHelper.reveal({ disputeId, roundId, voters })
+      context('when the round was appealed', () => {
+        beforeEach('appeal', async () => {
+          await courtHelper.appeal({ disputeId, roundId })
+        })
+
+        itIsAtState(roundId, ROUND_STATES.CONFIRMING_APPEAL)
+        itFailsToCommitVotes()
+        itFailsToRevealVotes()
+      })
+    })
+
+    context('after the appeal confirmation period', () => {
+      beforeEach('commit and reveal votes', async () => {
+        await courtHelper.commit({ disputeId, roundId, voters })
+        await courtHelper.reveal({ disputeId, roundId, voters })
+      })
+
+      context('when the round was not appealed', () => {
+        beforeEach('pass appeal and confirmation periods', async () => {
           await courtHelper.passTerms(courtHelper.appealTerms.add(courtHelper.appealConfirmTerms))
         })
 
@@ -377,6 +215,166 @@ contract('Court', ([_, disputer, drafter, juror100, juror500, juror1000, juror15
         itFailsToCommitVotes()
         itFailsToRevealVotes()
       })
+
+      context('when the round was appealed', () => {
+        beforeEach('appeal', async () => {
+          await courtHelper.appeal({ disputeId, roundId })
+        })
+
+        context('when the appeal was not confirmed', () => {
+          beforeEach('pass appeal confirmation period', async () => {
+            await courtHelper.passTerms(courtHelper.appealConfirmTerms)
+          })
+
+          itIsAtState(roundId, ROUND_STATES.ENDED)
+          itFailsToCommitVotes()
+          itFailsToRevealVotes()
+        })
+
+        context('when the appeal was confirmed', () => {
+          beforeEach('confirm appeal', async () => {
+            await courtHelper.confirmAppeal({ disputeId, roundId })
+          })
+
+          itIsAtState(roundId, ROUND_STATES.ENDED)
+          itFailsToCommitVotes()
+          itFailsToRevealVotes()
+        })
+      })
+    })
+  })
+
+  context('for a final round', () => {
+    const roundId = DEFAULTS.maxRegularAppealRounds.toNumber(), poorJuror = juror100
+
+    beforeEach('simulate juror without enough balance to vote on a final round', async () => {
+      await court.collect(poorJuror, bigExp(99, 18))
+      await courtHelper.passTerms(bn(1))
+
+      const { active } = await courtHelper.jurorsRegistry.balanceOf(poorJuror)
+      assert.equal(active.toString(), bigExp(1, 18).toString(), 'poor juror active balance does not match')
+    })
+
+    beforeEach('move to final round', async () => {
+      await courtHelper.moveToFinalRound({ disputeId })
+    })
+
+    beforeEach('define a group of voters', async () => {
+      voteId = getVoteId(disputeId, roundId)
+      voters = [
+        { address: juror1000, outcome: OUTCOMES.LOW },
+        { address: juror4000, outcome: OUTCOMES.LOW },
+        { address: juror2000, outcome: OUTCOMES.HIGH },
+        { address: juror1500, outcome: OUTCOMES.REFUSED },
+      ]
+      nonVoters = filterJurors(jurors, voters)
+    })
+
+    context('during commit period', () => {
+      itIsAtState(roundId, ROUND_STATES.COMMITTING)
+      itFailsToRevealVotes()
+
+      context('when the sender has enough active balance', () => {
+        it('allows to commit a vote', async () => {
+          for (const { address, outcome } of voters) {
+            const receipt = await voting.commit(voteId, encryptVote(outcome), { from: address })
+            assertAmountOfEvents(receipt, 'VoteCommitted')
+          }
+        })
+      })
+
+      context('when the sender does not have enough active balance', () => {
+        it('reverts', async () => {
+          await assertRevert(voting.commit(voteId, encryptVote(OUTCOMES.LOW), { from: poorJuror }), 'CRV_COMMIT_DENIED_BY_OWNER')
+        })
+      })
+    })
+
+    context('during reveal period', () => {
+      beforeEach('commit votes', async () => {
+        await courtHelper.commit({ disputeId, roundId, voters })
+      })
+
+      itIsAtState(roundId, ROUND_STATES.REVEALING)
+      itFailsToCommitVotes()
+
+      context('when the sender voted', () => {
+        let receipts, expectedTally
+
+        beforeEach('reveal votes', async () => {
+          receipts = []
+          expectedTally = { [OUTCOMES.LOW]: 0, [OUTCOMES.HIGH]: 0 }
+
+          for (const { address, outcome } of voters) {
+            const { weight } = await courtHelper.getRoundJuror(disputeId, roundId, address)
+            expectedTally[outcome] += weight.toNumber()
+            receipts.push(await voting.reveal(voteId, outcome, SALT, { from: address }))
+          }
+        })
+
+        it('allows voters to reveal their vote', async () => {
+          for (let i = 0; i < voters.length; i++) {
+            const { address, outcome } = voters[i]
+            assertEvent(receipts[i], 'VoteRevealed', { voteId, voter: address, outcome })
+          }
+        })
+
+        it('computes tallies properly', async () => {
+          const lowOutcomeTally = await voting.getOutcomeTally(voteId, OUTCOMES.LOW)
+          assert.equal(lowOutcomeTally.toString(), expectedTally[OUTCOMES.LOW], 'low outcome tally does not match')
+
+          const highOutcomeTally = await voting.getOutcomeTally(voteId, OUTCOMES.HIGH)
+          assert.equal(highOutcomeTally.toString(), expectedTally[OUTCOMES.HIGH], 'high outcome tally does not match')
+
+          const winningOutcome = await voting.getWinningOutcome(voteId)
+          const expectedWinningOutcome = highOutcomeTally > lowOutcomeTally ? OUTCOMES.HIGH : OUTCOMES.LOW
+          assert.equal(winningOutcome.toString(), expectedWinningOutcome, 'winning outcome does not match')
+        })
+      })
+
+      context('when the sender did not vote', () => {
+        it('reverts', async () => {
+          for (const { address } of nonVoters) {
+            const expectedReason = address === poorJuror ? 'CRV_REVEAL_DENIED_BY_OWNER' : 'CRV_INVALID_COMMITMENT_SALT'
+            await assertRevert(voting.reveal(voteId, OUTCOMES.LOW, SALT, { from: address }), expectedReason)
+          }
+        })
+      })
+    })
+
+    context('during appeal period', () => {
+      beforeEach('commit and reveal votes', async () => {
+        await courtHelper.commit({ disputeId, roundId, voters })
+        await courtHelper.reveal({ disputeId, roundId, voters })
+      })
+
+      itIsAtState(roundId, ROUND_STATES.ENDED)
+      itFailsToCommitVotes()
+      itFailsToRevealVotes()
+    })
+
+    context('during the appeal confirmation period', () => {
+      beforeEach('commit and reveal votes, and pass appeal period', async () => {
+        await courtHelper.commit({ disputeId, roundId, voters })
+        await courtHelper.reveal({ disputeId, roundId, voters })
+        await courtHelper.passTerms(courtHelper.appealTerms)
+      })
+
+      itIsAtState(roundId, ROUND_STATES.ENDED)
+      itFailsToCommitVotes()
+      itFailsToRevealVotes()
+    })
+
+    context('after the appeal confirmation period', () => {
+      beforeEach('commit and reveal votes, and pass appeal and confirmation periods', async () => {
+        await courtHelper.commit({ disputeId, roundId, voters })
+        await courtHelper.reveal({ disputeId, roundId, voters })
+        await courtHelper.passTerms(courtHelper.appealTerms.add(courtHelper.appealConfirmTerms))
+      })
+
+      itIsAtState(roundId, ROUND_STATES.ENDED)
+      itFailsToCommitVotes()
+      itFailsToRevealVotes()
     })
   })
 })


### PR DESCRIPTION
Before, when tests were failing in the first before clause, it was
hard to know which test was:

```
  1) Contract: Court
       "before each" hook: create court for "round is at state 1":
     Error: Returned error: VM Exception while processing transaction: out of gas
     at PromiEvent (node_modules/truffle/build/webpack:/packages/contract/lib/promievent.js:6:1)
      at /home/bingen/workspace/aragon-court/node_modules/truffle/build/webpack:/packages/contract/lib/execute.js:211:1
      at Function.new (node_modules/truffle/build/webpack:/packages/contract/lib/contract/constructorMethods.js:33:1)
      at CourtHelper.deploy (test/helpers/court.js:376:60)
      at process._tickCallback (internal/process/next_tick.js:68:7)
```