### PR TITLE
Court & Registry: move final round computations to registry

### DIFF
--- a/contracts/court/Court.sol
+++ b/contracts/court/Court.sol
@@ -1033,7 +1033,7 @@ contract Court is IJurorsRegistryOwner, ICRVotingOwner, ISubscriptionsOwner, Tim
         if (_isRegularRound(_roundId, config)) {
             weight = _getStoredJurorWeight(round, _juror);
         } else {
-            (, uint256 shares) = jurorsRegistry.getActiveBalanceInfo(_juror, round.draftTermId, FINAL_ROUND_WEIGHT_PRECISION);
+            (, uint256 shares) = jurorsRegistry.getActiveBalanceInfoOfAt(_juror, round.draftTermId, FINAL_ROUND_WEIGHT_PRECISION);
             weight = shares.toUint64();
         }
 
@@ -1261,7 +1261,11 @@ contract Court is IJurorsRegistryOwner, ICRVotingOwner, ISubscriptionsOwner, Tim
         internal returns (uint64)
     {
         // If the juror weight for the last round is zero, return zero
-        (uint256 activeBalance, uint256 shares) = jurorsRegistry.getActiveBalanceInfo(_juror, _round.draftTermId, FINAL_ROUND_WEIGHT_PRECISION);
+        (uint256 activeBalance, uint256 shares) = jurorsRegistry.getActiveBalanceInfoOfAt(
+            _juror,
+            _round.draftTermId,
+            FINAL_ROUND_WEIGHT_PRECISION
+        );
         if (shares == 0) {
             return uint64(0);
         }
@@ -1463,6 +1467,9 @@ contract Court is IJurorsRegistryOwner, ICRVotingOwner, ISubscriptionsOwner, Tim
             nextRound.newDisputeState = DisputeState.Adjudicating;
             // The number of jurors will be the number of times the minimum stake is hold in the registry,
             // multiplied by a precision factor to help with division rounding.
+            // Total active balance is guaranteed to never be greater than
+            // `2^64 * minActiveBalance / FINAL_ROUND_WEIGHT_PRECISION`. Thus, the
+            // jurors number for a final round will always fit in `uint64`
             nextRound.nextRoundJurorsNumber = jurorsRegistry.getTotalMinActiveBalanceShares(
                 nextRound.nextRoundStartTerm,
                 FINAL_ROUND_WEIGHT_PRECISION

--- a/contracts/court/Court.sol
+++ b/contracts/court/Court.sol
@@ -1033,8 +1033,8 @@ contract Court is IJurorsRegistryOwner, ICRVotingOwner, ISubscriptionsOwner, Tim
         if (_isRegularRound(_roundId, config)) {
             weight = _getStoredJurorWeight(round, _juror);
         } else {
-            (, uint256 shares) = jurorsRegistry.getActiveBalanceInfoOfAt(_juror, round.draftTermId, FINAL_ROUND_WEIGHT_PRECISION);
-            weight = shares.toUint64();
+            (, uint256 minActiveBalanceMultiple) = jurorsRegistry.getActiveBalanceInfoOfAt(_juror, round.draftTermId, FINAL_ROUND_WEIGHT_PRECISION);
+            weight = minActiveBalanceMultiple.toUint64();
         }
 
         rewarded = round.jurorsStates[_juror].rewarded;
@@ -1261,12 +1261,12 @@ contract Court is IJurorsRegistryOwner, ICRVotingOwner, ISubscriptionsOwner, Tim
         internal returns (uint64)
     {
         // If the juror weight for the last round is zero, return zero
-        (uint256 activeBalance, uint256 shares) = jurorsRegistry.getActiveBalanceInfoOfAt(
+        (uint256 activeBalance, uint256 minActiveBalanceMultiple) = jurorsRegistry.getActiveBalanceInfoOfAt(
             _juror,
             _round.draftTermId,
             FINAL_ROUND_WEIGHT_PRECISION
         );
-        if (shares == 0) {
+        if (minActiveBalanceMultiple == 0) {
             return uint64(0);
         }
 
@@ -1280,7 +1280,7 @@ contract Court is IJurorsRegistryOwner, ICRVotingOwner, ISubscriptionsOwner, Tim
         }
 
         // If it was possible to collect the amount of active tokens to be locked, update the final round state
-        uint64 weight = shares.toUint64();
+        uint64 weight = minActiveBalanceMultiple.toUint64();
         _round.jurorsStates[_juror].weight = weight;
         _round.collectedTokens = _round.collectedTokens.add(weightedPenalty);
         return weight;
@@ -1470,7 +1470,7 @@ contract Court is IJurorsRegistryOwner, ICRVotingOwner, ISubscriptionsOwner, Tim
             // Total active balance is guaranteed to never be greater than
             // `2^64 * minActiveBalance / FINAL_ROUND_WEIGHT_PRECISION`. Thus, the
             // jurors number for a final round will always fit in `uint64`
-            nextRound.nextRoundJurorsNumber = jurorsRegistry.getTotalMinActiveBalanceShares(
+            nextRound.nextRoundJurorsNumber = jurorsRegistry.getTotalMinActiveBalanceMultiple(
                 nextRound.nextRoundStartTerm,
                 FINAL_ROUND_WEIGHT_PRECISION
             ).toUint64();

--- a/contracts/registry/IJurorsRegistry.sol
+++ b/contracts/registry/IJurorsRegistry.sol
@@ -33,6 +33,6 @@ interface IJurorsRegistry {
 
     function getTotalMinActiveBalanceShares(uint64 _termId, uint256 _precision) external view returns (uint256);
 
-    function getActiveBalanceInfo(address _juror, uint64 _termId, uint256 _precision) external view
+    function getActiveBalanceInfoOfAt(address _juror, uint64 _termId, uint256 _precision) external view
         returns (uint256 activeBalance, uint256 shares);
 }

--- a/contracts/registry/IJurorsRegistry.sol
+++ b/contracts/registry/IJurorsRegistry.sol
@@ -30,4 +30,9 @@ interface IJurorsRegistry {
     function activeBalanceOfAt(address _juror, uint64 _termId) external view returns (uint256);
 
     function totalActiveBalanceAt(uint64 _termId) external view returns (uint256);
+
+    function getTotalMinActiveBalanceShares(uint64 _termId, uint256 _precision) external view returns (uint256);
+
+    function getActiveBalanceInfo(address _juror, uint64 _termId, uint256 _precision) external view
+        returns (uint256 activeBalance, uint256 shares);
 }

--- a/contracts/registry/IJurorsRegistry.sol
+++ b/contracts/registry/IJurorsRegistry.sol
@@ -31,7 +31,7 @@ interface IJurorsRegistry {
 
     function totalActiveBalanceAt(uint64 _termId) external view returns (uint256);
 
-    function getTotalMinActiveBalanceShares(uint64 _termId, uint256 _precision) external view returns (uint256);
+    function getTotalMinActiveBalanceMultiple(uint64 _termId, uint256 _precision) external view returns (uint256);
 
     function getActiveBalanceInfoOfAt(address _juror, uint64 _termId, uint256 _precision) external view
         returns (uint256 activeBalance, uint256 shares);

--- a/contracts/registry/JurorsRegistry.sol
+++ b/contracts/registry/JurorsRegistry.sol
@@ -393,19 +393,19 @@ contract JurorsRegistry is Initializable, IsContract, IJurorsRegistry, ERC900, A
     }
 
     /**
-    * @dev Calculate the number of times that the total active balance contains the min active balance.
+    * @dev Calculate the number of times that the total active balance contains the min active balance (multiplied by inputted precision).
     *      Used to calculate the jurors number for final rounds at the current term.
     * @param _termId Term querying that multiple
     * @param _precision Multiplier to mitigate division rounding errors
     * @return The number of times that the total active balance contains the min active balance.
     *         Equals Jurors number for final rounds for the given term.
     */
-    function getTotalMinActiveBalanceShares(uint64 _termId, uint256 _precision) external view returns (uint256) {
+    function getTotalMinActiveBalanceMultiple(uint64 _termId, uint256 _precision) external view returns (uint256) {
         return _precision.mul(_totalActiveBalanceAt(_termId)) / minActiveBalance;
     }
 
     /**
-    * @dev Calculate a juror's active balance and the number of times that it contains the min active balance.
+    * @dev Calculate a juror's active balance and the number of times that it contains the min active balance (multiplied by precision).
     *      Used to get the juror weight for the final round. Note that for the final round the weight of
     *      each juror is equal to the number of times the min active balance the juror has, multiplied by a precision
     *      factor to deal with division rounding.
@@ -415,7 +415,7 @@ contract JurorsRegistry is Initializable, IsContract, IJurorsRegistry, ERC900, A
     * @return Weight of the requested juror for the final round of the given dispute
     */
     function getActiveBalanceInfoOfAt(address _juror, uint64 _termId, uint256 _precision)
-        external view returns (uint256 activeBalance, uint256 shares)
+        external view returns (uint256 activeBalance, uint256 minActiveBalanceMultiple)
     {
         activeBalance = _activeBalanceOfAt(_juror, _termId);
 
@@ -427,7 +427,7 @@ contract JurorsRegistry is Initializable, IsContract, IJurorsRegistry, ERC900, A
 
         // Otherwise, return the times the active balance of the juror fits in the min active balance, multiplying
         // it by a round factor to ensure a better precision rounding.
-        shares = _precision.mul(activeBalance) / minActiveBalance;
+        minActiveBalanceMultiple = _precision.mul(activeBalance) / minActiveBalance;
     }
 
     /**

--- a/contracts/registry/JurorsRegistry.sol
+++ b/contracts/registry/JurorsRegistry.sol
@@ -401,9 +401,6 @@ contract JurorsRegistry is Initializable, IsContract, IJurorsRegistry, ERC900, A
     *         Equals Jurors number for final rounds for the given term.
     */
     function getTotalMinActiveBalanceShares(uint64 _termId, uint256 _precision) external view returns (uint256) {
-        // Total active balance is guaranteed to never be greater than
-        // `2^64 * minActiveBalance / FINAL_ROUND_WEIGHT_PRECISION`. Thus, the
-        // jurors number for a final round will always fit in `uint64`
         return _precision.mul(_totalActiveBalanceAt(_termId)) / minActiveBalance;
     }
 
@@ -417,7 +414,7 @@ contract JurorsRegistry is Initializable, IsContract, IJurorsRegistry, ERC900, A
     * @param _precision Multiplier to mitigate division rounding errors
     * @return Weight of the requested juror for the final round of the given dispute
     */
-    function getActiveBalanceInfo(address _juror, uint64 _termId, uint256 _precision)
+    function getActiveBalanceInfoOfAt(address _juror, uint64 _termId, uint256 _precision)
         external view returns (uint256 activeBalance, uint256 shares)
     {
         activeBalance = _activeBalanceOfAt(_juror, _termId);


### PR DESCRIPTION
Avoid some calls to registry, reduce Court contract size a little bit.

:warning: Merge after #163 and change base to development.