### PR TITLE
Court: Optimize config getters

### DIFF
--- a/contracts/controller/Controlled.sol
+++ b/contracts/controller/Controlled.sol
@@ -4,14 +4,14 @@ import "@aragon/os/contracts/common/IsContract.sol";
 
 import "./Controller.sol";
 import "./clock/IClock.sol";
-import "./config/CourtConfigData.sol";
+import "./config/ConfigConsumer.sol";
 import "../voting/ICRVoting.sol";
 import "../treasury/ITreasury.sol";
 import "../registry/IJurorsRegistry.sol";
 import "../subscriptions/ISubscriptions.sol";
 
 
-contract Controlled is IsContract, CourtConfigData {
+contract Controlled is IsContract, ConfigConsumer {
     string private constant ERROR_CONTROLLER_NOT_CONTRACT = "CTD_CONTROLLER_NOT_CONTRACT";
     string private constant ERROR_SENDER_NOT_COURT_MODULE = "CTD_SENDER_NOT_COURT_MODULE";
     string private constant ERROR_SENDER_NOT_CONFIG_GOVERNOR = "CTD_SENDER_NOT_CONFIG_GOVERNOR";
@@ -146,57 +146,5 @@ contract Controlled is IsContract, CourtConfigData {
     */
     function _court() internal view returns (address) {
         return controller.getCourt();
-    }
-
-    /**
-    * @dev Internal function to get the Court config for a certain term
-    * @param _termId Term querying the Court config of
-    * @return Court config for the given term
-    */
-    function _getConfigAt(uint64 _termId) internal view returns (Config memory) {
-        (ERC20 _feeToken,
-        uint256[3] memory _fees,
-        uint64[4] memory _roundStateDurations,
-        uint16[2] memory _pcts,
-        uint64[4] memory _roundParams,
-        uint256[2] memory _appealCollateralParams,
-        uint256 _minActiveBalance) = _config().getConfig(_termId);
-
-        Config memory config;
-
-        config.fees = FeesConfig({
-            token: _feeToken,
-            jurorFee: _fees[0],
-            draftFee: _fees[1],
-            settleFee: _fees[2],
-            finalRoundReduction: _pcts[1]
-        });
-
-        config.disputes = DisputesConfig({
-            commitTerms: _roundStateDurations[0],
-            revealTerms: _roundStateDurations[1],
-            appealTerms: _roundStateDurations[2],
-            appealConfirmTerms: _roundStateDurations[3],
-            penaltyPct: _pcts[0],
-            firstRoundJurorsNumber: _roundParams[0],
-            appealStepFactor: _roundParams[1],
-            maxRegularAppealRounds: _roundParams[2],
-            finalRoundLockTerms: _roundParams[3],
-            appealCollateralFactor: _appealCollateralParams[0],
-            appealConfirmCollateralFactor: _appealCollateralParams[1]
-        });
-
-        config.minActiveBalance = _minActiveBalance;
-
-        return config;
-    }
-
-    /**
-    * @dev Internal function to get the min active balance config for a given term
-    * @param _termId Identification number of the term querying the min active balance config of
-    * @return Minimum amount of juror tokens that can be activated
-    */
-    function _getMinActiveBalance(uint64 _termId) internal view returns (uint256) {
-        return _config().getMinActiveBalance(_termId);
     }
 }

--- a/contracts/controller/Controller.sol
+++ b/contracts/controller/Controller.sol
@@ -292,6 +292,18 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     }
 
     /**
+    * @dev Tell the draft config at a certain term
+    * @param _termId Term querying the draft config of
+    * @return feeToken Address of the token used to pay for fees
+    * @return draftFee Amount of fee tokens per juror to cover the drafting cost
+    * @return penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
+    */
+    function getDraftConfig(uint64 _termId) external view returns (ERC20 feeToken, uint256 draftFee, uint16 penaltyPct) {
+        uint64 lastEnsuredTermId = _lastEnsuredTermId();
+        return _getDraftConfig(_termId, lastEnsuredTermId);
+    }
+
+    /**
     * @dev Tell the address of the funds governor
     * @return Address of the funds governor
     */

--- a/contracts/controller/Controller.sol
+++ b/contracts/controller/Controller.sol
@@ -292,6 +292,30 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     }
 
     /**
+    * @dev Tell the create-dispute config at a certain term
+    * @param _termId Identification number of the term querying the create-dispute config of
+    * @return token ERC20 token to be used for the fees of the Court
+    * @return finalRoundReduction Permyriad of fees reduction applied for final appeal round (‱ - 1/10,000)
+    * @return jurorFee Amount of tokens paid to draft a juror to adjudicate a dispute
+    * @return draftFee Amount of tokens paid per round to cover the costs of drafting jurors
+    * @return settleFee Amount of tokens paid per round to cover the costs of slashing jurors
+    * @return firstRoundJurorsNumber Number of jurors drafted on first round
+    */
+    function getCreateDisputeConfig(uint64 _termId) external view
+        returns (
+            ERC20 token,
+            uint16 finalRoundReduction,
+            uint256 jurorFee,
+            uint256 draftFee,
+            uint256 settleFee,
+            uint64 firstRoundJurorsNumber
+        )
+    {
+        uint64 lastEnsuredTermId = _lastEnsuredTermId();
+        return _getCreateDisputeConfig(_termId, lastEnsuredTermId);
+    }
+
+    /**
     * @dev Tell the draft config at a certain term
     * @param _termId Term querying the draft config of
     * @return feeToken Address of the token used to pay for fees

--- a/contracts/controller/config/ConfigConsumer.sol
+++ b/contracts/controller/config/ConfigConsumer.sol
@@ -1,0 +1,77 @@
+pragma solidity ^0.5.8;
+
+import "@aragon/os/contracts/lib/token/ERC20.sol";
+
+import "./IConfig.sol";
+import "./CourtConfigData.sol";
+
+
+contract ConfigConsumer is CourtConfigData {
+    /**
+    * @dev Internal function to fetch the address of the Config module from the controller
+    * @return Address of the Config module
+    */
+    function _config() internal view returns (IConfig);
+
+    /**
+    * @dev Internal function to get the Court config for a certain term
+    * @param _termId Term querying the Court config of
+    * @return Court config for the given term
+    */
+    function _getConfigAt(uint64 _termId) internal view returns (Config memory) {
+        (ERC20 _feeToken,
+        uint256[3] memory _fees,
+        uint64[4] memory _roundStateDurations,
+        uint16[2] memory _pcts,
+        uint64[4] memory _roundParams,
+        uint256[2] memory _appealCollateralParams,
+        uint256 _minActiveBalance) = _config().getConfig(_termId);
+
+        Config memory config;
+
+        config.fees = FeesConfig({
+            token: _feeToken,
+            jurorFee: _fees[0],
+            draftFee: _fees[1],
+            settleFee: _fees[2],
+            finalRoundReduction: _pcts[1]
+        });
+
+        config.disputes = DisputesConfig({
+            commitTerms: _roundStateDurations[0],
+            revealTerms: _roundStateDurations[1],
+            appealTerms: _roundStateDurations[2],
+            appealConfirmTerms: _roundStateDurations[3],
+            penaltyPct: _pcts[0],
+            firstRoundJurorsNumber: _roundParams[0],
+            appealStepFactor: _roundParams[1],
+            maxRegularAppealRounds: _roundParams[2],
+            finalRoundLockTerms: _roundParams[3],
+            appealCollateralFactor: _appealCollateralParams[0],
+            appealConfirmCollateralFactor: _appealCollateralParams[1]
+        });
+
+        config.minActiveBalance = _minActiveBalance;
+
+        return config;
+    }
+
+    /**
+    * @dev Internal function to get the min active balance config for a given term
+    * @param _termId Identification number of the term querying the min active balance config of
+    * @return Minimum amount of juror tokens that can be activated
+    */
+    function _getMinActiveBalance(uint64 _termId) internal view returns (uint256) {
+        return _config().getMinActiveBalance(_termId);
+    }
+
+    /**
+    * @dev Internal function to get the draft config for a given term
+    * @param _termId Identification number of the term querying the draft config of
+    * @return Draft config for the given term
+    */
+    function _getDraftConfig(uint64 _termId) internal view returns (DraftConfig memory) {
+        (ERC20 feeToken, uint256 draftFee, uint16 penaltyPct) = _config().getDraftConfig(_termId);
+        return DraftConfig({ feeToken: feeToken, draftFee: draftFee, penaltyPct: penaltyPct });
+    }
+}

--- a/contracts/controller/config/ConfigConsumer.sol
+++ b/contracts/controller/config/ConfigConsumer.sol
@@ -66,6 +66,33 @@ contract ConfigConsumer is CourtConfigData {
     }
 
     /**
+    * @dev Internal function to get the create-dispute config for a given term
+    * @param _termId Identification number of the term querying the draft config of
+    * @return Create-dispute config for the given term
+    */
+    function _getCreateDisputeConfig(uint64 _termId) internal view returns (CreateDisputeConfig memory) {
+        (ERC20 token,
+        uint16 finalRoundReduction,
+        uint256 jurorFee,
+        uint256 draftFee,
+        uint256 settleFee,
+        uint64 firstRoundJurorsNumber) = _config().getCreateDisputeConfig(_termId);
+
+        CreateDisputeConfig memory config;
+
+        config.fees = FeesConfig({
+            token: token,
+            jurorFee: jurorFee,
+            draftFee: draftFee,
+            settleFee: settleFee,
+            finalRoundReduction: finalRoundReduction
+        });
+
+        config.firstRoundJurorsNumber = firstRoundJurorsNumber;
+        return config;
+    }
+
+    /**
     * @dev Internal function to get the draft config for a given term
     * @param _termId Identification number of the term querying the draft config of
     * @return Draft config for the given term

--- a/contracts/controller/config/CourtConfig.sol
+++ b/contracts/controller/config/CourtConfig.sol
@@ -259,7 +259,7 @@ contract CourtConfig is IConfig, CourtConfigData {
             uint256 minActiveBalance
         )
     {
-        Config storage config = configs[_getConfigIdFor(_termId, _lastEnsuredTermId)];
+        Config storage config = _getConfigFor(_termId, _lastEnsuredTermId);
 
         FeesConfig storage feesConfig = config.fees;
         feeToken = feesConfig.token;
@@ -288,15 +288,41 @@ contract CourtConfig is IConfig, CourtConfigData {
     * @dev Internal function to get the min active balance config for a given term
     * @param _termId Identification number of the term querying the min active balance config of
     * @param _lastEnsuredTermId Identification number of the last ensured term of the Court
-    * @return Minimum amount of juror tokens that can be activated
+    * @return Minimum amount of juror tokens that can be activated at the given term
     */
     function _getMinActiveBalance(uint64 _termId, uint64 _lastEnsuredTermId) internal view returns (uint256) {
-        Config storage config = configs[_getConfigIdFor(_termId, _lastEnsuredTermId)];
+        Config storage config = _getConfigFor(_termId, _lastEnsuredTermId);
         return config.minActiveBalance;
     }
 
     /**
+    * @dev Tell the draft config at a certain term
+    * @param _termId Identification number of the term querying the draft config of
+    * @param _lastEnsuredTermId Identification number of the last ensured term of the Court
+    * @return feeToken Address of the token used to pay for fees
+    * @return draftFee Amount of fee tokens per juror to cover the drafting cost
+    * @return penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
+    */
+    function _getDraftConfig(uint64 _termId,  uint64 _lastEnsuredTermId) internal view
+        returns (ERC20 feeToken, uint256 draftFee, uint16 penaltyPct)
+    {
+        Config storage config = _getConfigFor(_termId, _lastEnsuredTermId);
+        return (config.fees.token, config.fees.draftFee, config.disputes.penaltyPct);
+    }
+
+    /**
     * @dev Internal function to get the Court config for a given term
+    * @param _termId Identification number of the term querying the min active balance config of
+    * @param _lastEnsuredTermId Identification number of the last ensured term of the Court
+    * @return Court config for the given term
+    */
+    function _getConfigFor(uint64 _termId, uint64 _lastEnsuredTermId) internal view returns (Config storage) {
+        uint256 id = _getConfigIdFor(_termId, _lastEnsuredTermId);
+        return configs[id];
+    }
+
+    /**
+    * @dev Internal function to get the Court config ID for a given term
     * @param _termId Identification number of the term querying the Court config of
     * @param _lastEnsuredTermId Identification number of the last ensured term of the Court
     * @return Identification number of the config for the given terms

--- a/contracts/controller/config/CourtConfig.sol
+++ b/contracts/controller/config/CourtConfig.sol
@@ -296,6 +296,38 @@ contract CourtConfig is IConfig, CourtConfigData {
     }
 
     /**
+    * @dev Tell the create-dispute config at a certain term
+    * @param _termId Identification number of the term querying the create-dispute config of
+    * @param _lastEnsuredTermId Identification number of the last ensured term of the Court
+    * @return token ERC20 token to be used for the fees of the Court
+    * @return finalRoundReduction Permyriad of fees reduction applied for final appeal round (‱ - 1/10,000)
+    * @return jurorFee Amount of tokens paid to draft a juror to adjudicate a dispute
+    * @return draftFee Amount of tokens paid per round to cover the costs of drafting jurors
+    * @return settleFee Amount of tokens paid per round to cover the costs of slashing jurors
+    * @return firstRoundJurorsNumber Number of jurors drafted on first round
+    */
+    function _getCreateDisputeConfig(uint64 _termId,  uint64 _lastEnsuredTermId) internal view
+        returns (
+            ERC20 token,
+            uint16 finalRoundReduction,
+            uint256 jurorFee,
+            uint256 draftFee,
+            uint256 settleFee,
+            uint64 firstRoundJurorsNumber
+        )
+    {
+        Config storage config = _getConfigFor(_termId, _lastEnsuredTermId);
+        FeesConfig storage feesConfig = config.fees;
+
+        token = feesConfig.token;
+        jurorFee = feesConfig.jurorFee;
+        draftFee = feesConfig.draftFee;
+        settleFee = feesConfig.settleFee;
+        finalRoundReduction = feesConfig.finalRoundReduction;
+        firstRoundJurorsNumber = config.disputes.firstRoundJurorsNumber;
+    }
+
+    /**
     * @dev Tell the draft config at a certain term
     * @param _termId Identification number of the term querying the draft config of
     * @param _lastEnsuredTermId Identification number of the last ensured term of the Court

--- a/contracts/controller/config/CourtConfigData.sol
+++ b/contracts/controller/config/CourtConfigData.sol
@@ -31,4 +31,10 @@ contract CourtConfigData {
         uint256 appealCollateralFactor;         // Permyriad multiple of juror fees required to appeal a preliminary ruling (‱ - 1/10,000)
         uint256 appealConfirmCollateralFactor;  // Permyriad multiple of juror fees required to confirm appeal (‱ - 1/10,000)
     }
+
+    struct DraftConfig {
+        ERC20 feeToken;                         // ERC20 token to be used for the fees of the Court
+        uint16 penaltyPct;                      // Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
+        uint256 draftFee;                       // Amount of tokens paid per round to cover the costs of drafting jurors
+    }
 }

--- a/contracts/controller/config/CourtConfigData.sol
+++ b/contracts/controller/config/CourtConfigData.sol
@@ -5,8 +5,8 @@ import "@aragon/os/contracts/lib/token/ERC20.sol";
 
 contract CourtConfigData {
     struct Config {
-        FeesConfig fees;
-        DisputesConfig disputes;
+        FeesConfig fees;                        // Full fees-related config
+        DisputesConfig disputes;                // Full disputes-related config
         uint256 minActiveBalance;               // Minimum amount of tokens jurors have to activate to participate in the Court
     }
 
@@ -30,6 +30,11 @@ contract CourtConfigData {
         uint256 maxRegularAppealRounds;         // Before the final appeal
         uint256 appealCollateralFactor;         // Permyriad multiple of juror fees required to appeal a preliminary ruling (‱ - 1/10,000)
         uint256 appealConfirmCollateralFactor;  // Permyriad multiple of juror fees required to confirm appeal (‱ - 1/10,000)
+    }
+
+    struct CreateDisputeConfig {
+        FeesConfig fees;                        // Full fees-related config
+        uint64 firstRoundJurorsNumber;          // Number of jurors drafted on first round
     }
 
     struct DraftConfig {

--- a/contracts/controller/config/IConfig.sol
+++ b/contracts/controller/config/IConfig.sol
@@ -51,6 +51,25 @@ interface IConfig {
     /**
     * @dev Tell the draft config at a certain term
     * @param _termId Term querying the draft config of
+    * @return finalRoundReduction Permyriad of fees reduction applied for final appeal round (‱ - 1/10,000)
+    * @return jurorFee Amount of tokens paid to draft a juror to adjudicate a dispute
+    * @return draftFee Amount of tokens paid per round to cover the costs of drafting jurors
+    * @return settleFee Amount of tokens paid per round to cover the costs of slashing jurors
+    * @return firstRoundJurorsNumber Number of jurors drafted on first round
+    */
+    function getCreateDisputeConfig(uint64 _termId) external view
+        returns (
+            ERC20 token,
+            uint16 finalRoundReduction,
+            uint256 jurorFee,
+            uint256 draftFee,
+            uint256 settleFee,
+            uint64 firstRoundJurorsNumber
+        );
+
+    /**
+    * @dev Tell the draft config at a certain term
+    * @param _termId Term querying the draft config of
     * @return feeToken Address of the token used to pay for fees
     * @return draftFee Amount of fee tokens per juror to cover the drafting cost
     * @return penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)

--- a/contracts/controller/config/IConfig.sol
+++ b/contracts/controller/config/IConfig.sol
@@ -43,8 +43,17 @@ interface IConfig {
 
     /**
     * @dev Tell the min active balance config at a certain term
-    * @param _termId Term querying the Court config of
+    * @param _termId Term querying the min active balance config of
     * @return Minimum amount of tokens jurors have to activate to participate in the Court
     */
     function getMinActiveBalance(uint64 _termId) external view returns (uint256);
+
+    /**
+    * @dev Tell the draft config at a certain term
+    * @param _termId Term querying the draft config of
+    * @return feeToken Address of the token used to pay for fees
+    * @return draftFee Amount of fee tokens per juror to cover the drafting cost
+    * @return penaltyPct Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
+    */
+    function getDraftConfig(uint64 _termId) external view returns (ERC20 feeToken, uint256 draftFee, uint16 penaltyPct);
 }

--- a/contracts/court/Court.sol
+++ b/contracts/court/Court.sol
@@ -203,8 +203,8 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
         Dispute storage dispute = disputes[disputeId];
         dispute.subject = _subject;
         dispute.possibleRulings = _possibleRulings;
-        Config memory config = _getConfigAt(draftTermId);
-        uint64 jurorsNumber = config.disputes.firstRoundJurorsNumber;
+        CreateDisputeConfig memory config = _getCreateDisputeConfig(draftTermId);
+        uint64 jurorsNumber = config.firstRoundJurorsNumber;
         emit NewDispute(disputeId, address(_subject), draftTermId, jurorsNumber);
 
         // Create first adjudication round of the dispute

--- a/contracts/court/Court.sol
+++ b/contracts/court/Court.sol
@@ -260,7 +260,8 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
         // Ensure current term and check that the given round can be appealed.
         // Note that if there was a final appeal the adjudication state will be 'Ended'.
         Dispute storage dispute = disputes[_disputeId];
-        _checkAdjudicationState(dispute, _roundId, AdjudicationState.Appealing);
+        Config memory config = _getDisputeConfig(dispute);
+        _checkAdjudicationState(dispute, _roundId, AdjudicationState.Appealing, config.disputes);
 
         // Ensure that the ruling being appealed in favor of is valid and different from the current winning ruling
         ICRVoting voting = _voting();
@@ -276,7 +277,7 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
         emit RulingAppealed(_disputeId, _roundId, _ruling);
 
         // Pay appeal deposit
-        NextRoundDetails memory nextRound = _getNextRoundDetails(dispute, round, _roundId);
+        NextRoundDetails memory nextRound = _getNextRoundDetails(round, _roundId, config);
         _depositSenderAmount(nextRound.feeToken, nextRound.appealDeposit);
     }
 
@@ -290,7 +291,8 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
         // Ensure current term and check that the given round is appealed and can be confirmed.
         // Note that if there was a final appeal the adjudication state will be 'Ended'.
         Dispute storage dispute = disputes[_disputeId];
-        _checkAdjudicationState(dispute, _roundId, AdjudicationState.ConfirmingAppeal);
+        Config memory config = _getDisputeConfig(dispute);
+        _checkAdjudicationState(dispute, _roundId, AdjudicationState.ConfirmingAppeal, config.disputes);
 
         // Ensure that the ruling being confirmed in favor of is valid and different from the appealed ruling
         AdjudicationRound storage round = dispute.rounds[_roundId];
@@ -299,7 +301,7 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
         require(appeal.appealedRuling != _ruling && _voting().isValidOutcome(voteId, _ruling), ERROR_INVALID_APPEAL_RULING);
 
         // Create a new adjudication round for the dispute
-        NextRoundDetails memory nextRound = _getNextRoundDetails(dispute, round, _roundId);
+        NextRoundDetails memory nextRound = _getNextRoundDetails(round, _roundId, config);
         DisputeState newDisputeState = nextRound.newDisputeState;
         uint256 newRoundId = _createRound(_disputeId, newDisputeState, nextRound.startTerm, nextRound.jurorsNumber, nextRound.jurorFees);
 
@@ -320,7 +322,9 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
         Dispute storage dispute = disputes[_disputeId];
         require(dispute.state != DisputeState.Executed, ERROR_INVALID_DISPUTE_STATE);
 
-        uint8 finalRuling = _ensureFinalRuling(_disputeId);
+        Config memory config = _getDisputeConfig(dispute);
+        uint8 finalRuling = _ensureFinalRuling(dispute, _disputeId, config);
+
         dispute.state = DisputeState.Executed;
         dispute.subject.rule(_disputeId, uint256(finalRuling));
         emit RulingExecuted(_disputeId, finalRuling);
@@ -346,8 +350,11 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
         AdjudicationRound storage round = dispute.rounds[_roundId];
         require(!round.settledPenalties, ERROR_ROUND_ALREADY_SETTLED);
 
+        // Ensure the final ruling of the given dispute is already computed
+        Config memory config = _getDisputeConfig(dispute);
+        uint8 finalRuling = _ensureFinalRuling(dispute, _disputeId, config);
+
         // Set the number of jurors that voted in favor of the final ruling if we haven't started settling yet
-        uint8 finalRuling = _ensureFinalRuling(_disputeId);
         uint256 voteId = _getVoteId(_disputeId, _roundId);
         if (round.settledJurors == 0) {
             // Note that we are safe to cast the tally of a ruling to uint64 since the highest value a ruling can have is equal to the jurors
@@ -356,10 +363,8 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
             round.coherentJurors = uint64(voting.getOutcomeTally(voteId, finalRuling));
         }
 
-        Config memory config = _getDisputeConfig(dispute);
         ITreasury treasury = _treasury();
         ERC20 feeToken = config.fees.token;
-
         if (_isRegularRound(_roundId, config)) {
             // For regular appeal rounds we compute the amount of locked tokens that needs to get burned in batches.
             // The callers of this function will get rewarded in this case.
@@ -451,7 +456,8 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
         emit AppealDepositSettled(_disputeId, _roundId);
 
         // Load next round details
-        NextRoundDetails memory nextRound = _getNextRoundDetails(dispute, round, _roundId);
+        Config memory config = _getDisputeConfig(dispute);
+        NextRoundDetails memory nextRound = _getNextRoundDetails(round, _roundId, config);
         ERC20 feeToken = nextRound.feeToken;
         uint256 totalFees = nextRound.totalFees;
         uint256 appealDeposit = nextRound.appealDeposit;
@@ -490,9 +496,10 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
     */
     function ensureCanCommit(uint256 _voteId) external {
         (Dispute storage dispute, uint256 roundId) = _decodeVoteId(_voteId);
+        Config memory config = _getDisputeConfig(dispute);
 
         // Ensure current term and check that votes can still be committed for the given round
-        _checkAdjudicationState(dispute, roundId, AdjudicationState.Committing);
+        _checkAdjudicationState(dispute, roundId, AdjudicationState.Committing, config.disputes);
     }
 
     /**
@@ -503,10 +510,11 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
     */
     function ensureCanCommit(uint256 _voteId, address _voter) external onlyVoting {
         (Dispute storage dispute, uint256 roundId) = _decodeVoteId(_voteId);
+        Config memory config = _getDisputeConfig(dispute);
 
         // Ensure current term and check that votes can still be committed for the given round
-        _checkAdjudicationState(dispute, roundId, AdjudicationState.Committing);
-        uint64 weight = _computeJurorWeight(dispute, roundId, _voter);
+        _checkAdjudicationState(dispute, roundId, AdjudicationState.Committing, config.disputes);
+        uint64 weight = _computeJurorWeight(dispute, roundId, _voter, config);
         require(weight > 0, ERROR_VOTER_WEIGHT_ZERO);
     }
 
@@ -519,9 +527,10 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
     */
     function ensureCanReveal(uint256 _voteId, address _voter) external returns (uint64) {
         (Dispute storage dispute, uint256 roundId) = _decodeVoteId(_voteId);
+        Config memory config = _getDisputeConfig(dispute);
 
         // Ensure current term and check that votes can still be revealed for the given round
-        _checkAdjudicationState(dispute, roundId, AdjudicationState.Revealing);
+        _checkAdjudicationState(dispute, roundId, AdjudicationState.Revealing, config.disputes);
         AdjudicationRound storage round = dispute.rounds[roundId];
         return _getJurorWeight(round, _voter);
     }
@@ -598,7 +607,7 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
         )
     {
         Dispute storage dispute = disputes[_disputeId];
-        state = _adjudicationStateAt(dispute, _roundId, _getCurrentTermId());
+        state = _adjudicationStateAt(dispute, _roundId, _getCurrentTermId(), _getDisputeConfig(dispute).disputes);
 
         AdjudicationRound storage round = dispute.rounds[_roundId];
         draftTerm = round.draftTermId;
@@ -645,7 +654,7 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
     * @return appealDeposit Amount to be deposit of fees for a regular round at the given term
     * @return confirmAppealDeposit Total amount of fees for a regular round at the given term
     */
-    function getNextRoundDetails(uint256 _disputeId, uint256 _roundId) external view roundExists(_disputeId, _roundId)
+    function getNextRoundDetails(uint256 _disputeId, uint256 _roundId) external view
         returns (
             uint64 nextRoundStartTerm,
             uint64 nextRoundJurorsNumber,
@@ -657,9 +666,14 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
             uint256 confirmAppealDeposit
         )
     {
+        _checkRoundExists(_disputeId, _roundId);
+
         Dispute storage dispute = disputes[_disputeId];
-        require(_isRegularRound(_roundId, _getDisputeConfig(dispute)), ERROR_ROUND_IS_FINAL);
-        NextRoundDetails memory nextRound = _getNextRoundDetails(dispute, dispute.rounds[_roundId], _roundId);
+        Config memory config = _getDisputeConfig(dispute);
+        require(_isRegularRound(_roundId, config), ERROR_ROUND_IS_FINAL);
+
+        AdjudicationRound storage round = dispute.rounds[_roundId];
+        NextRoundDetails memory nextRound = _getNextRoundDetails(round, _roundId, config);
         return (
             nextRound.startTerm,
             nextRound.jurorsNumber,
@@ -735,32 +749,37 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
     * @param _dispute Dispute to be checked
     * @param _roundId Identification number of the dispute round to be checked
     * @param _state Expected adjudication state for the given dispute round
+    * @param _config Config at the draft term ID of the given dispute
     */
-    function _checkAdjudicationState(Dispute storage _dispute, uint256 _roundId, AdjudicationState _state) internal {
+    function _checkAdjudicationState(Dispute storage _dispute, uint256 _roundId, AdjudicationState _state, DisputesConfig memory _config)
+        internal
+    {
         uint64 termId = _ensureCurrentTerm();
-        require(_adjudicationStateAt(_dispute, _roundId, termId) == _state, ERROR_INVALID_ADJUDICATION_STATE);
+        AdjudicationState roundState = _adjudicationStateAt(_dispute, _roundId, termId, _config);
+        require(roundState == _state, ERROR_INVALID_ADJUDICATION_STATE);
     }
 
     /**
     * @dev Internal function to ensure the final ruling of a dispute. It will compute it only if missing.
+    * @param _dispute Dispute to ensure its final ruling
     * @param _disputeId Identification number of the dispute to ensure its final ruling
+    * @param _config Config at the draft term ID of the given dispute
     * @return Number of the final ruling ensured for the given dispute
     */
-    function _ensureFinalRuling(uint256 _disputeId) internal returns (uint8) {
+    function _ensureFinalRuling(Dispute storage _dispute, uint256 _disputeId, Config memory _config) internal returns (uint8) {
         // Check if there was a final ruling already cached
-        Dispute storage dispute = disputes[_disputeId];
-        if (uint256(dispute.finalRuling) > 0) {
-            return dispute.finalRuling;
+        if (uint256(_dispute.finalRuling) > 0) {
+            return _dispute.finalRuling;
         }
 
         // Ensure current term and check that the last adjudication round has ended.
         // Note that there will always be at least one round.
-        uint256 lastRoundId = dispute.rounds.length - 1;
-        _checkAdjudicationState(dispute, lastRoundId, AdjudicationState.Ended);
+        uint256 lastRoundId = _dispute.rounds.length - 1;
+        _checkAdjudicationState(_dispute, lastRoundId, AdjudicationState.Ended, _config.disputes);
 
         // If the last adjudication round was appealed but no-one confirmed it, the final ruling is the outcome the
         // appealer vouched for. Otherwise, fetch the winning outcome from the voting app of the last round.
-        AdjudicationRound storage lastRound = dispute.rounds[lastRoundId];
+        AdjudicationRound storage lastRound = _dispute.rounds[lastRoundId];
         Appeal storage lastAppeal = lastRound.appeal;
         bool isRoundAppealedAndNotConfirmed = _existsAppeal(lastAppeal) && !_isAppealConfirmed(lastAppeal);
         uint8 finalRuling = isRoundAppealedAndNotConfirmed
@@ -768,7 +787,7 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
             : _voting().getWinningOutcome(_getVoteId(_disputeId, lastRoundId));
 
         // Store the winning ruling as the final decision for the given dispute
-        dispute.finalRuling = finalRuling;
+        _dispute.finalRuling = finalRuling;
         return finalRuling;
     }
 
@@ -836,15 +855,15 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
     * @param _dispute Dispute to calculate the juror's weight of
     * @param _roundId ID of the dispute's round to calculate the juror's weight of
     * @param _juror Address of the juror to calculate the weight of
+    * @param _config Config at the draft term ID of the given dispute
     * @return Computed weight of the requested juror for the final round of the given dispute
     */
-    function _computeJurorWeight(Dispute storage _dispute, uint256 _roundId, address _juror) internal returns (uint64) {
+    function _computeJurorWeight(Dispute storage _dispute, uint256 _roundId, address _juror, Config memory _config) internal returns (uint64) {
         AdjudicationRound storage round = _dispute.rounds[_roundId];
-        Config memory config = _getDisputeConfig(_dispute);
 
-        return _isRegularRound(_roundId, config)
+        return _isRegularRound(_roundId, _config)
             ? _getJurorWeight(round, _juror)
-            : _computeJurorWeightForFinalRound(config, round, _juror);
+            : _computeJurorWeightForFinalRound(_config, round, _juror);
     }
 
     /**
@@ -922,17 +941,16 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
     /**
     * @dev Internal function to tell information related to the next round due to an appeal of a certain round given. This function assumes
     *      given round can be appealed and that the given round ID corresponds to the given round pointer.
-    * @param _dispute Round's dispute requesting the appeal details of
     * @param _round Round requesting the appeal details of
     * @param _roundId Identification number of the round requesting the appeal details of
+    * @param _config Config at the draft term of the given dispute
     * @return Next round details
     */
-    function _getNextRoundDetails(Dispute storage _dispute, AdjudicationRound storage _round, uint256 _roundId) internal view
+    function _getNextRoundDetails(AdjudicationRound storage _round, uint256 _roundId, Config memory _config) internal view
         returns (NextRoundDetails memory)
     {
         NextRoundDetails memory nextRound;
-        Config memory config = _getDisputeConfig(_dispute);
-        DisputesConfig memory disputesConfig = config.disputes;
+        DisputesConfig memory disputesConfig = _config.disputes;
 
         // No need for SafeMath: round state durations are safely capped and we assume that timestamps,
         // and its derivatives like term ID, won't reach MAX_UINT64, which would be ~5.8e11 years.
@@ -951,17 +969,17 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
             // Thus, the jurors number for a final round will always fit in uint64.
             IJurorsRegistry jurorsRegistry = _jurorsRegistry();
             uint256 totalActiveBalance = jurorsRegistry.totalActiveBalanceAt(nextRound.startTerm);
-            uint64 jurorsNumber = _getMinActiveBalanceMultiple(totalActiveBalance, config.minActiveBalance);
+            uint64 jurorsNumber = _getMinActiveBalanceMultiple(totalActiveBalance, _config.minActiveBalance);
             nextRound.jurorsNumber = jurorsNumber;
             // Calculate fees for the final round using the appeal start term of the current round
-            (nextRound.feeToken, nextRound.jurorFees, nextRound.totalFees) = _getFinalRoundFees(config.fees, jurorsNumber);
+            (nextRound.feeToken, nextRound.jurorFees, nextRound.totalFees) = _getFinalRoundFees(_config.fees, jurorsNumber);
         } else {
             // For a new regular rounds we need to draft jurors
             nextRound.newDisputeState = DisputeState.PreDraft;
             // The number of jurors will be the number of jurors of the current round multiplied by an appeal factor
             nextRound.jurorsNumber = _getNextRegularRoundJurorsNumber(_round, disputesConfig);
             // Calculate fees for the next regular round using the appeal start term of the current round
-            (nextRound.feeToken, nextRound.jurorFees, nextRound.totalFees) = _getRegularRoundFees(config.fees, nextRound.jurorsNumber);
+            (nextRound.feeToken, nextRound.jurorFees, nextRound.totalFees) = _getRegularRoundFees(_config.fees, nextRound.jurorsNumber);
         }
 
         // Calculate appeal collateral
@@ -992,11 +1010,13 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
     * @param _dispute Dispute querying the adjudication round of
     * @param _roundId Identification number of the dispute round querying the adjudication round of
     * @param _termId Identification number of the term to be used for the different round phases durations
+    * @param _config Disputes config at the draft term ID of the given dispute
     * @return Adjudication state of the requested dispute round for the given term
     */
-    function _adjudicationStateAt(Dispute storage _dispute, uint256 _roundId, uint64 _termId) internal view returns (AdjudicationState) {
+    function _adjudicationStateAt(Dispute storage _dispute, uint256 _roundId, uint64 _termId, DisputesConfig memory _config) internal view
+        returns (AdjudicationState)
+    {
         AdjudicationRound storage round = _dispute.rounds[_roundId];
-        Config memory config = _getDisputeConfig(_dispute);
 
         // If the dispute is executed or the given round is not the last one, we consider it ended
         uint256 numberOfRounds = _dispute.rounds.length;
@@ -1014,20 +1034,20 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
 
         // If given term is before the reveal start term of the last round, then jurors are still allowed to commit votes for the last round
         // No need for SafeMath: round state durations are safely capped at config
-        uint64 revealStartTerm = draftFinishedTermId + config.disputes.commitTerms;
+        uint64 revealStartTerm = draftFinishedTermId + _config.commitTerms;
         if (_termId < revealStartTerm) {
             return AdjudicationState.Committing;
         }
 
         // If given term is before the appeal start term of the last round, then jurors are still allowed to reveal votes for the last round
         // No need for SafeMath: round state durations are safely capped at config
-        uint64 appealStartTerm = revealStartTerm + config.disputes.revealTerms;
+        uint64 appealStartTerm = revealStartTerm + _config.revealTerms;
         if (_termId < appealStartTerm) {
             return AdjudicationState.Revealing;
         }
 
         // If the max number of appeals has been reached, then the last round is the final round and can be considered ended
-        bool maxAppealReached = numberOfRounds > config.disputes.maxRegularAppealRounds;
+        bool maxAppealReached = numberOfRounds > _config.maxRegularAppealRounds;
         if (maxAppealReached) {
             return AdjudicationState.Ended;
         }
@@ -1035,7 +1055,7 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
         // If the last round was not appealed yet, check if the confirmation period has started or not
         bool isLastRoundAppealed = _existsAppeal(round.appeal);
         // No need for SafeMath: round state durations are safely capped at config
-        uint64 appealConfirmationStartTerm = appealStartTerm + config.disputes.appealTerms;
+        uint64 appealConfirmationStartTerm = appealStartTerm + _config.appealTerms;
         if (!isLastRoundAppealed) {
             // If given term is before the appeal confirmation start term, then the last round can still be appealed. Otherwise, it is ended.
             if (_termId < appealConfirmationStartTerm) {
@@ -1049,7 +1069,7 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
         // confirmed. Note that if the round being checked was already appealed and confirmed, it won't be the last round, thus it will be caught
         // above by the first check and considered 'Ended'.
         // No need for SafeMath: round state durations are safely capped at config
-        uint64 appealConfirmationEndTerm = appealConfirmationStartTerm + config.disputes.appealConfirmTerms;
+        uint64 appealConfirmationEndTerm = appealConfirmationStartTerm + _config.appealConfirmTerms;
         if (_termId < appealConfirmationEndTerm) {
             return AdjudicationState.ConfirmingAppeal;
         }

--- a/test/court/court-gas.js
+++ b/test/court/court-gas.js
@@ -107,7 +107,7 @@ contract('Court', ([_, sender, disputer, drafter, appealMaker, appealTaker, juro
           assertBn(neededTransitions, 0, 'needed transitions does not match')
         })
 
-        itCostsAtMost('commit', 94e3, () => voting.commit(voteId, vote, { from: draftedJurors[0].address }))
+        itCostsAtMost('commit', 78e3, () => voting.commit(voteId, vote, { from: draftedJurors[0].address }))
       })
 
       context('when the current term is outdated by one term', () => {
@@ -189,7 +189,7 @@ contract('Court', ([_, sender, disputer, drafter, appealMaker, appealTaker, juro
           assertBn(neededTransitions, 0, 'needed transitions does not match')
         })
 
-        itCostsAtMost('createAppeal', 90e3, () => court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker }))
+        itCostsAtMost('createAppeal', 74e3, () => court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker }))
       })
 
       context('when the current term is outdated by one term', () => {
@@ -199,7 +199,7 @@ contract('Court', ([_, sender, disputer, drafter, appealMaker, appealTaker, juro
           assertBn(neededTransitions, 1, 'needed transitions does not match')
         })
 
-        itCostsAtMost('createAppeal', 146e3, () => court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker }))
+        itCostsAtMost('createAppeal', 130e3, () => court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker }))
       })
     })
 
@@ -234,7 +234,7 @@ contract('Court', ([_, sender, disputer, drafter, appealMaker, appealTaker, juro
           assertBn(neededTransitions, 0, 'needed transitions does not match')
         })
 
-        itCostsAtMost('confirmAppeal', 194e3, () => court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker }))
+        itCostsAtMost('confirmAppeal', 179e3, () => court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker }))
       })
 
       context('when the current term is outdated by one term', () => {
@@ -244,7 +244,7 @@ contract('Court', ([_, sender, disputer, drafter, appealMaker, appealTaker, juro
           assertBn(neededTransitions, 1, 'needed transitions does not match')
         })
 
-        itCostsAtMost('confirmAppeal', 251e3, () => court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker }))
+        itCostsAtMost('confirmAppeal', 235e3, () => court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker }))
       })
     })
 
@@ -271,7 +271,7 @@ contract('Court', ([_, sender, disputer, drafter, appealMaker, appealTaker, juro
           assertBn(neededTransitions, 0, 'needed transitions does not match')
         })
 
-        itCostsAtMost('executeRuling', 68e3, () => court.executeRuling(disputeId))
+        itCostsAtMost('executeRuling', 67e3, () => court.executeRuling(disputeId))
       })
 
       context('when the current term is outdated by one term', () => {
@@ -311,7 +311,7 @@ contract('Court', ([_, sender, disputer, drafter, appealMaker, appealTaker, juro
           assertBn(neededTransitions, 0, 'needed transitions does not match')
         })
 
-        itCostsAtMost('settlePenalties', 213e3, () => court.settlePenalties(disputeId, roundId, 0))
+        itCostsAtMost('settlePenalties', 197e3, () => court.settlePenalties(disputeId, roundId, 0))
       })
 
       context('when the current term is outdated by one term', () => {
@@ -321,7 +321,7 @@ contract('Court', ([_, sender, disputer, drafter, appealMaker, appealTaker, juro
           assertBn(neededTransitions, 1, 'needed transitions does not match')
         })
 
-        itCostsAtMost('settlePenalties', 269e3, () => court.settlePenalties(disputeId, roundId, 0))
+        itCostsAtMost('settlePenalties', 253e3, () => court.settlePenalties(disputeId, roundId, 0))
       })
     })
 

--- a/test/court/court-gas.js
+++ b/test/court/court-gas.js
@@ -83,7 +83,7 @@ contract('Court', ([_, sender, disputer, drafter, appealMaker, appealTaker, juro
         await controller.mockSetTermRandomness('0x0000000000000000000000000000000000000000000000000000000000000001')
       })
 
-      itCostsAtMost('draft', 337e3, () => court.draft(disputeId))
+      itCostsAtMost('draft', 325e3, () => court.draft(disputeId))
     })
 
     describe('commit', () => {

--- a/test/court/court-gas.js
+++ b/test/court/court-gas.js
@@ -55,7 +55,7 @@ contract('Court', ([_, sender, disputer, drafter, appealMaker, appealTaker, juro
           assertBn(neededTransitions, 0, 'needed transitions does not match')
         })
 
-        itCostsAtMost('createDispute', 217e3, () => court.createDispute(arbitrable.address, 2, { from: sender }))
+        itCostsAtMost('createDispute', 209e3, () => court.createDispute(arbitrable.address, 2, { from: sender }))
       })
 
       context('when the current term is outdated by one term', () => {
@@ -65,7 +65,7 @@ contract('Court', ([_, sender, disputer, drafter, appealMaker, appealTaker, juro
           assertBn(neededTransitions, 1, 'needed transitions does not match')
         })
 
-        itCostsAtMost('createDispute', 273e3, () => court.createDispute(arbitrable.address, 2, { from: sender }))
+        itCostsAtMost('createDispute', 265e3, () => court.createDispute(arbitrable.address, 2, { from: sender }))
       })
     })
 
@@ -117,7 +117,7 @@ contract('Court', ([_, sender, disputer, drafter, appealMaker, appealTaker, juro
           assertBn(neededTransitions, 1, 'needed transitions does not match')
         })
 
-        itCostsAtMost('commit', 150e3, () => voting.commit(voteId, vote, { from: draftedJurors[0].address }))
+        itCostsAtMost('commit', 135e3, () => voting.commit(voteId, vote, { from: draftedJurors[0].address }))
       })
     })
 


### PR DESCRIPTION
Fixes #185 

This PR includes the following changes:
- Optimized config getter for creating disputes
- Optimized config getter for drafting
- Make sure config is fetched only once in the rest of the Court entry points (a step towards #107)
