### PR TITLE
Court: Add metadata argument for disputes

### DIFF
--- a/contracts/court/Court.sol
+++ b/contracts/court/Court.sol
@@ -134,7 +134,7 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
     Dispute[] internal disputes;
 
     event DisputeStateChanged(uint256 indexed disputeId, DisputeState indexed state);
-    event NewDispute(uint256 indexed disputeId, address indexed subject, uint64 indexed draftTermId, uint64 jurorsNumber);
+    event NewDispute(uint256 indexed disputeId, address indexed subject, uint64 indexed draftTermId, uint64 jurorsNumber, bytes metadata);
     event RulingAppealed(uint256 indexed disputeId, uint256 indexed roundId, uint8 ruling);
     event RulingAppealConfirmed(uint256 indexed disputeId, uint256 indexed roundId, uint64 indexed draftTermId, uint256 jurorsNumber);
     event RulingExecuted(uint256 indexed disputeId, uint8 indexed ruling);
@@ -186,9 +186,10 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
     * @dev Create a dispute to be drafted in a future term
     * @param _subject Arbitrable subject being disputed
     * @param _possibleRulings Number of possible rulings allowed for the drafted jurors to vote on the dispute
+    * @param _metadata Optional metadata that can be used to provide additional information on the dispute to be created
     * @return Dispute identification number
     */
-    function createDispute(IArbitrable _subject, uint8 _possibleRulings) external returns (uint256) {
+    function createDispute(IArbitrable _subject, uint8 _possibleRulings, bytes calldata _metadata) external returns (uint256) {
         // TODO: Limit the min amount of terms before drafting (to allow for evidence submission)
         // TODO: ERC165 check that _subject conforms to the Arbitrable interface
         // TODO: require(address(_subject) == msg.sender, ERROR_INVALID_DISPUTE_CREATOR);
@@ -205,7 +206,7 @@ contract Court is ControlledRecoverable, ICRVotingOwner {
         dispute.possibleRulings = _possibleRulings;
         CreateDisputeConfig memory config = _getCreateDisputeConfig(draftTermId);
         uint64 jurorsNumber = config.firstRoundJurorsNumber;
-        emit NewDispute(disputeId, address(_subject), draftTermId, jurorsNumber);
+        emit NewDispute(disputeId, address(_subject), draftTermId, jurorsNumber, _metadata);
 
         // Create first adjudication round of the dispute
         (ERC20 feeToken, uint256 jurorFees, uint256 totalFees) = _getRegularRoundFees(config.fees, jurorsNumber);

--- a/docs/4-entry-points/2-court.md
+++ b/docs/4-entry-points/2-court.md
@@ -21,8 +21,9 @@ It is also in charge of executing the associated `Arbitrables` once the dispute 
 
 - **Actor:** Proposal Agreements instances, entities that need a dispute adjudicated
 - **Inputs:**
-    - **Subject:** address of the `Arbitrable` contract where the dispute originates
-    - **Possible rulings:** number of possible results for a dispute
+    - **Subject:** Address of the `Arbitrable` contract where the dispute originates
+    - **Possible rulings:** Number of possible results for a dispute
+    - **Metadata:** Optional metadata that can be used to provide additional information on the dispute to be created
 - **Authentication:** Open. Implicitly, only smart contracts that are up to date on their subscriptions in the `Subscription` module and that have open an ERC20 allowance with an amount of at least the dispute fee to the `Court` module can call this function
 - **Pre-flight checks:**
     - Ensure that the Court term is up-to-date. Otherwise, perform a heartbeat before continuing the execution.

--- a/docs/6-external-interface/2-court.md
+++ b/docs/6-external-interface/2-court.md
@@ -12,6 +12,7 @@ The following events are emitted by the `Court`:
     - **Subject:** Address of the `Arbitrable` subject associated to the dispute
     - **Draft term ID:** Identification number of the term when the dispute will be able to be drafted
     - **Jurors number:** First round jurors number 
+    - **Metadata:** Optional metadata that can be used to provide additional information on the created dispute 
 
 #### 6.2.1.2. Dispute changed
 

--- a/test/court/court-gas.js
+++ b/test/court/court-gas.js
@@ -53,7 +53,7 @@ contract('Court', ([_, sender, disputer, drafter, appealMaker, appealTaker, juro
           assertBn(neededTransitions, 0, 'needed transitions does not match')
         })
 
-        itCostsAtMost('createDispute', 209e3, () => court.createDispute(arbitrable.address, 2, { from: sender }))
+        itCostsAtMost('createDispute', 210e3, () => court.createDispute(arbitrable.address, 2, '0x', { from: sender }))
       })
 
       context('when the current term is outdated by one term', () => {
@@ -63,7 +63,7 @@ contract('Court', ([_, sender, disputer, drafter, appealMaker, appealTaker, juro
           assertBn(neededTransitions, 1, 'needed transitions does not match')
         })
 
-        itCostsAtMost('createDispute', 265e3, () => court.createDispute(arbitrable.address, 2, { from: sender }))
+        itCostsAtMost('createDispute', 266e3, () => court.createDispute(arbitrable.address, 2, '0x', { from: sender }))
       })
     })
 

--- a/test/helpers/wrappers/court.js
+++ b/test/helpers/wrappers/court.js
@@ -137,7 +137,7 @@ module.exports = (web3, artifacts) => {
       }
     }
 
-    async dispute({ draftTermId, possibleRulings = bn(2), arbitrable = undefined, disputer = undefined }) {
+    async dispute({ draftTermId, possibleRulings = bn(2), metadata = '0x', arbitrable = undefined, disputer = undefined }) {
       // mint enough fee tokens for the disputer, if no disputer was given pick the second account
       if (!disputer) disputer = await this._getAccount(1)
       await this.setTerm(draftTermId - 1)
@@ -149,7 +149,7 @@ module.exports = (web3, artifacts) => {
       await this.subscriptions.setUpToDate(true)
 
       // create dispute and return id
-      const receipt = await this.court.createDispute(arbitrable.address, possibleRulings, { from: disputer })
+      const receipt = await this.court.createDispute(arbitrable.address, possibleRulings, metadata, { from: disputer })
       return getEventArgument(receipt, COURT_EVENTS.NEW_DISPUTE, 'disputeId')
     }
 


### PR DESCRIPTION
*This is the first of a 4-series PRs*

This PR simply aims to add an arbitrary `metadata` field to the `NewDispute` event that can be used by consumers to provide additional information for each created dispute.