### PR TITLE
Court: Implement disputes resolution oracle interface

### DIFF
--- a/contracts/controller/Controlled.sol
+++ b/contracts/controller/Controlled.sol
@@ -13,6 +13,7 @@ import "../subscriptions/ISubscriptions.sol";
 
 contract Controlled is IsContract, ConfigConsumer {
     string private constant ERROR_CONTROLLER_NOT_CONTRACT = "CTD_CONTROLLER_NOT_CONTRACT";
+    string private constant ERROR_SENDER_NOT_CONTROLLER = "CTD_SENDER_NOT_CONTROLLER";
     string private constant ERROR_SENDER_NOT_COURT_MODULE = "CTD_SENDER_NOT_COURT_MODULE";
     string private constant ERROR_SENDER_NOT_CONFIG_GOVERNOR = "CTD_SENDER_NOT_CONFIG_GOVERNOR";
 
@@ -32,6 +33,14 @@ contract Controlled is IsContract, ConfigConsumer {
     */
     modifier onlyConfigGovernor {
         require(msg.sender == _configGovernor(), ERROR_SENDER_NOT_CONFIG_GOVERNOR);
+        _;
+    }
+
+    /**
+    * @dev Ensure the msg.sender is the controller
+    */
+    modifier onlyController() {
+        require(msg.sender == address(controller), ERROR_SENDER_NOT_CONTROLLER);
         _;
     }
 

--- a/contracts/controller/Controller.sol
+++ b/contracts/controller/Controller.sol
@@ -5,9 +5,10 @@ import "../lib/os/IsContract.sol";
 
 import "./clock/CourtClock.sol";
 import "./config/CourtConfig.sol";
+import "./oracle/DisputeResolutionOracle.sol";
 
 
-contract Controller is IsContract, CourtClock, CourtConfig {
+contract Controller is IsContract, CourtClock, CourtConfig, DisputeResolutionOracle {
     string private constant ERROR_SENDER_NOT_GOVERNOR = "CTR_SENDER_NOT_GOVERNOR";
     string private constant ERROR_SENDER_NOT_COURT_MODULE = "CTR_SENDER_NOT_COURT_MODULE";
     string private constant ERROR_INVALID_GOVERNOR_ADDRESS = "CTR_INVALID_GOVERNOR_ADDRESS";
@@ -373,7 +374,7 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     * @return Address of the Court module
     */
     function getCourt() external view returns (address) {
-        return _getModule(COURT);
+        return _getCourt();
     }
 
     /**
@@ -405,7 +406,7 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     * @return Address of the Subscriptions module
     */
     function getSubscriptions() external view returns (address) {
-        return _getModule(SUBSCRIPTIONS);
+        return _getSubscriptions();
     }
 
     /**
@@ -452,6 +453,22 @@ contract Controller is IsContract, CourtClock, CourtConfig {
     */
     function _onTermTransitioned(uint64 _currentTermId) internal {
         _ensureTermConfig(_currentTermId);
+    }
+
+    /**
+    * @dev Internal function to tell the address of the Court module
+    * @return Address of the Court module
+    */
+    function _getCourt() internal view returns (address) {
+        return _getModule(COURT);
+    }
+
+    /**
+    * @dev Internal function to tell the address of the Subscriptions module
+    * @return Address of the Subscriptions module
+    */
+    function _getSubscriptions() internal view returns (address) {
+        return _getModule(SUBSCRIPTIONS);
     }
 
     /**

--- a/contracts/controller/oracle/DisputeResolutionOracle.sol
+++ b/contracts/controller/oracle/DisputeResolutionOracle.sol
@@ -1,0 +1,82 @@
+pragma solidity ^0.5.8;
+
+import "./IDisputeResolutionOracle.sol";
+import "../../court/ICourt.sol";
+import "../../arbitration/IArbitrable.sol";
+import "../../subscriptions/ISubscriptions.sol";
+import "../../lib/os/Uint256Helpers.sol";
+
+
+contract DisputeResolutionOracle is IDisputeResolutionOracle {
+    using Uint256Helpers for uint256;
+
+    string private constant ERROR_SENDER_NOT_ARBITRABLE = "CT_SENDER_NOT_ARBITRABLE";
+    string private constant ERROR_SUBSCRIPTION_NOT_PAID = "CT_SUBSCRIPTION_NOT_PAID";
+
+    // Arbitrable interface ID based on ERC-165
+    bytes4 private constant ARBITRABLE_INTERFACE_ID = bytes4(0x311a6c56);
+
+    /**
+    * @dev Create a dispute over the Arbitrable sender with a number of possible rulings
+    * @param _possibleRulings Number of possible rulings allowed for the drafted jurors to vote on the dispute
+    * @param _metadata Optional metadata that can be used to provide additional information on the dispute to be created
+    * @return Dispute identification number
+    */
+    function createDispute(uint256 _possibleRulings, bytes calldata _metadata) external returns (uint256) {
+        IArbitrable subject = IArbitrable(msg.sender);
+        require(subject.supportsInterface(ARBITRABLE_INTERFACE_ID), ERROR_SENDER_NOT_ARBITRABLE);
+
+        ISubscriptions subscriptions = ISubscriptions(_getSubscriptions());
+        require(subscriptions.isUpToDate(address(subject)), ERROR_SUBSCRIPTION_NOT_PAID);
+
+        ICourt court = ICourt(_getCourt());
+        return court.createDispute(subject, _possibleRulings.toUint8(), _metadata);
+    }
+
+    /**
+    * @dev Execute the arbitrable associated to a dispute based on its final ruling
+    * @param _disputeId Identification number of the dispute to be executed
+    */
+    function executeRuling(uint256 _disputeId) external {
+        ICourt court = ICourt(_getCourt());
+        (IArbitrable subject, uint8 ruling) = court.computeRuling(_disputeId);
+        subject.rule(_disputeId, uint256(ruling));
+    }
+
+    /**
+    * @dev Tell the dispute fees information to create a dispute
+    * @return recipient Address where the corresponding dispute fees must be transferred to
+    * @return feeToken ERC20 token used for the fees
+    * @return feeAmount Total amount of fees that must be allowed to the recipient
+    */
+    function getDisputeFees() external view returns (address recipient, ERC20 feeToken, uint256 feeAmount) {
+        recipient = _getCourt();
+        ICourt court = ICourt(recipient);
+        (feeToken, feeAmount) = court.getDisputeFees();
+    }
+
+    /**
+    * @dev Tell the subscription fees information for a subscriber to be up-to-date
+    * @param _subscriber Address of the account paying the subscription fees for
+    * @return recipient Address where the corresponding subscriptions fees must be transferred to
+    * @return feeToken ERC20 token used for the subscription fees
+    * @return feeAmount Total amount of fees that must be allowed to the recipient
+    */
+    function getSubscriptionFees(address _subscriber) external view returns (address recipient, ERC20 feeToken, uint256 feeAmount) {
+        recipient = _getSubscriptions();
+        ISubscriptions subscriptions = ISubscriptions(recipient);
+        (feeToken, feeAmount,) = subscriptions.getOwedFeesDetails(_subscriber);
+    }
+
+    /**
+    * @dev Internal function to tell the address of the Court module
+    * @return Address of the Court module
+    */
+    function _getCourt() internal view returns (address);
+
+    /**
+    * @dev Internal function to tell the address of the Subscriptions module
+    * @return Address of the Subscriptions module
+    */
+    function _getSubscriptions() internal view returns (address);
+}

--- a/contracts/controller/oracle/IDisputeResolutionOracle.sol
+++ b/contracts/controller/oracle/IDisputeResolutionOracle.sol
@@ -1,0 +1,38 @@
+pragma solidity ^0.5.8;
+
+import "../../lib/os/ERC20.sol";
+import "../../arbitration/IArbitrable.sol";
+
+
+interface IDisputeResolutionOracle {
+    /**
+    * @dev Create a dispute over the Arbitrable sender with a number of possible rulings
+    * @param _possibleRulings Number of possible rulings allowed for the dispute
+    * @param _metadata Optional metadata that can be used to provide additional information on the dispute to be created
+    * @return Dispute identification number
+    */
+    function createDispute(uint256 _possibleRulings, bytes calldata _metadata) external returns (uint256);
+
+    /**
+    * @dev Execute the Arbitrable associated to a dispute based on its final ruling
+    * @param _disputeId Identification number of the dispute to be executed
+    */
+    function executeRuling(uint256 _disputeId) external;
+
+    /**
+    * @dev Tell the dispute fees information to create a dispute
+    * @return recipient Address where the corresponding dispute fees must be transferred to
+    * @return feeToken ERC20 token used for the fees
+    * @return feeAmount Total amount of fees that must be allowed to the recipient
+    */
+    function getDisputeFees() external view returns (address recipient, ERC20 feeToken, uint256 feeAmount);
+
+    /**
+    * @dev Tell the subscription fees information for a subscriber to be up-to-date
+    * @param _subscriber Address of the account paying the subscription fees for
+    * @return recipient Address where the corresponding subscriptions fees must be transferred to
+    * @return feeToken ERC20 token used for the subscription fees
+    * @return feeAmount Total amount of fees that must be allowed to the recipient
+    */
+    function getSubscriptionFees(address _subscriber) external view returns (address recipient, ERC20 feeToken, uint256 feeAmount);
+}

--- a/contracts/court/ICourt.sol
+++ b/contracts/court/ICourt.sol
@@ -1,0 +1,30 @@
+pragma solidity ^0.5.8;
+
+import "../lib/os/ERC20.sol";
+import "../arbitration/IArbitrable.sol";
+
+
+interface ICourt {
+    /**
+    * @dev Create a dispute to be drafted in a future term
+    * @param _subject Arbitrable instance creating the dispute
+    * @param _possibleRulings Number of possible rulings allowed for the drafted jurors to vote on the dispute
+    * @param _metadata Optional metadata that can be used to provide additional information on the dispute to be created
+    * @return Dispute identification number
+    */
+    function createDispute(IArbitrable _subject, uint8 _possibleRulings, bytes calldata _metadata) external returns (uint256);
+
+    /**
+    * @notice Compute the final ruling of a dispute
+    * @param _disputeId Identification number of the dispute to be computed
+    * @return Final ruling decided for the given dispute
+    */
+    function computeRuling(uint256 _disputeId) external returns (IArbitrable, uint8);
+
+    /**
+    * @dev Tell the amount of token fees required to create a dispute
+    * @return feeToken ERC20 token used for the fees
+    * @return feeAmount Total amount of fees to be paid for a dispute at the given term
+    */
+    function getDisputeFees() external view returns (ERC20 feeToken, uint256 feeAmount);
+}

--- a/contracts/lib/os/Uint256Helpers.sol
+++ b/contracts/lib/os/Uint256Helpers.sol
@@ -5,12 +5,19 @@ pragma solidity ^0.5.8;
 
 
 library Uint256Helpers {
+    uint256 private constant MAX_UINT8 = uint8(-1);
     uint256 private constant MAX_UINT64 = uint64(-1);
 
-    string private constant ERROR_NUMBER_TOO_BIG = "UINT64_NUMBER_TOO_BIG";
+    string private constant ERROR_UINT8_NUMBER_TOO_BIG = "UINT8_NUMBER_TOO_BIG";
+    string private constant ERROR_UINT64_NUMBER_TOO_BIG = "UINT64_NUMBER_TOO_BIG";
+
+    function toUint8(uint256 a) internal pure returns (uint8) {
+        require(a <= MAX_UINT8, ERROR_UINT8_NUMBER_TOO_BIG);
+        return uint8(a);
+    }
 
     function toUint64(uint256 a) internal pure returns (uint64) {
-        require(a <= MAX_UINT64, ERROR_NUMBER_TOO_BIG);
+        require(a <= MAX_UINT64, ERROR_UINT64_NUMBER_TOO_BIG);
         return uint64(a);
     }
 }

--- a/contracts/subscriptions/ISubscriptions.sol
+++ b/contracts/subscriptions/ISubscriptions.sol
@@ -10,4 +10,13 @@ interface ISubscriptions {
     * @return True if subscriber has paid all the fees up to current period, false otherwise
     */
     function isUpToDate(address _subscriber) external view returns (bool);
+
+    /**
+    * @dev Tell the minimum amount of fees to pay and resulting last paid period for a given subscriber in order to be up-to-date
+    * @param _subscriber Address of the subscriber willing to pay
+    * @return feeToken ERC20 token used for the subscription fees
+    * @return amountToPay Amount of subscription fee tokens to be paid
+    * @return newLastPeriodId Identification number of the resulting last paid period
+    */
+    function getOwedFeesDetails(address _subscriber) external view returns (ERC20, uint256, uint256);
 }

--- a/contracts/test/arbitration/ArbitrableMock.sol
+++ b/contracts/test/arbitration/ArbitrableMock.sol
@@ -3,27 +3,28 @@ pragma solidity ^0.5.8;
 import "../../court/Court.sol";
 import "../../standards/ERC165.sol";
 import "../../arbitration/IArbitrable.sol";
+import "../../controller/oracle/IDisputeResolutionOracle.sol";
 
 
 contract ArbitrableMock is IArbitrable, ERC165 {
     bytes4 private constant ARBITRABLE_INTERFACE_ID = bytes4(0x311a6c56);
 
-    event CourtRuling(address indexed court, uint256 indexed disputeId, uint256 ruling);
+    event Ruled(address indexed oracle, uint256 indexed disputeId, uint256 ruling);
 
-    Court internal court;
+    IDisputeResolutionOracle internal oracle;
 
-    constructor (Court _court) public {
-        court = _court;
+    constructor (IDisputeResolutionOracle _oracle) public {
+        oracle = _oracle;
     }
 
     function createDispute(uint8 _possibleRulings, bytes calldata _metadata) external {
-        (ERC20 feeToken, uint256 disputeFees) = court.getDisputeFees();
-        feeToken.approve(address(court), disputeFees);
-        court.createDispute(_possibleRulings, _metadata);
+        (address recipient, ERC20 feeToken, uint256 disputeFees) = oracle.getDisputeFees();
+        feeToken.approve(recipient, disputeFees);
+        oracle.createDispute(_possibleRulings, _metadata);
     }
 
     function rule(uint256 _disputeId, uint256 _ruling) external {
-        emit CourtRuling(msg.sender, _disputeId, _ruling);
+        emit Ruled(msg.sender, _disputeId, _ruling);
     }
 
     function supportsInterface(bytes4 _interfaceId) external pure returns (bool) {

--- a/contracts/test/arbitration/FakeArbitrableMock.sol
+++ b/contracts/test/arbitration/FakeArbitrableMock.sol
@@ -4,7 +4,7 @@ import "./ArbitrableMock.sol";
 
 
 contract FakeArbitrableMock is ArbitrableMock {
-    constructor (Court _court) ArbitrableMock(_court) public {}
+    constructor (IDisputeResolutionOracle _court) ArbitrableMock(_court) public {}
 
     function supportsInterface(bytes4 /* _interfaceId */) external pure returns (bool) {
         return false;

--- a/contracts/test/subscriptions/SubscriptionsMock.sol
+++ b/contracts/test/subscriptions/SubscriptionsMock.sol
@@ -1,12 +1,36 @@
 pragma solidity ^0.5.8;
 
 import "../../subscriptions/ISubscriptions.sol";
+import "../../subscriptions/CourtSubscriptions.sol";
 
 
-contract SubscriptionsMock is ISubscriptions {
+contract SubscriptionsMock is CourtSubscriptions {
     bool internal upToDate;
 
-    function setUpToDate(bool _upToDate) external {
+    constructor(
+        Controller _controller,
+        uint64 _periodDuration,
+        ERC20 _feeToken,
+        uint256 _feeAmount,
+        uint256 _prePaymentPeriods,
+        uint256 _resumePrePaidPeriods,
+        uint16 _latePaymentPenaltyPct,
+        uint16 _governorSharePct
+    )
+        CourtSubscriptions(
+            _controller,
+            _periodDuration,
+            _feeToken,
+            _feeAmount,
+            _prePaymentPeriods,
+            _resumePrePaidPeriods,
+            _latePaymentPenaltyPct,
+            _governorSharePct
+        )
+        public
+    {}
+
+    function mockUpToDate(bool _upToDate) external {
         upToDate = _upToDate;
     }
 

--- a/docs/2-architecture/readme.md
+++ b/docs/2-architecture/readme.md
@@ -45,4 +45,3 @@ The protocol settings should be always able to be tweaked to ensure the proper o
 
 Any other modules functionality that needs to be restricted is either relying on these governor addresses as well, or on any of the other modules. 
 No other external accounts apart from the `Governor` addresses belong to the protocol implementation.
-  

--- a/docs/4-entry-points/1-controller.md
+++ b/docs/4-entry-points/1-controller.md
@@ -52,7 +52,34 @@ To read more information about its responsibilities and structure, go to [sectio
     - Create the initial Court configuration object
     - Create the governor object
 
-### 4.1.2. Set config
+### 4.1.2. Create dispute
+
+- **Actor:** Proposal Agreements instances, entities that need a dispute adjudicated
+- **Inputs:**
+    - **Possible rulings:** Number of possible results for a dispute
+    - **Metadata:** Optional metadata that can be used to provide additional information on the dispute to be created
+- **Authentication:** Open. Implicitly, only smart contracts that are up to date on their subscriptions in the `Subscription` module and that have open an ERC20 allowance with an amount of at least the dispute fee to the `Court` module can call this function
+- **Pre-flight checks:**
+    - Ensure that the msg.sender supports the `IArbitrable` interface
+    - Ensure that the subject is up-to-date on its subscription fees
+- **State transitions:**
+    - Create a new dispute object in the Court module
+
+### 4.1.3. Execute dispute
+
+- **Actor:** External entity incentivized to execute the final ruling decided for a dispute. Alternatively, an altruistic entity to make sure the dispute is ruled.
+- **Inputs:**
+    - **Dispute ID:** Dispute identification number
+- **Authentication:** Open
+- **Pre-flight checks:**
+    - Ensure a dispute object with that ID exists
+    - Ensure that the dispute has not been executed yet
+    - Ensure that the dispute's last round adjudication phase has ended
+- **State transitions:**
+    - Compute the final ruling in the Court module
+    - Execute the `Arbitrable` contract linked to the dispute based on the decided ruling
+
+### 4.1.4. Set config
 
 - **Actor:** External entity in charge of maintaining the Court protocol
 - **Inputs:**
@@ -93,7 +120,7 @@ To read more information about its responsibilities and structure, go to [sectio
     - Create a new Court configuration object
     - Create a new future term object for the new configuration
 
-### 4.1.3. Delay start time
+### 4.1.5. Delay start time
 
 - **Actor:** External entity in charge of maintaining the Court protocol
 - **Inputs:**
@@ -105,7 +132,7 @@ To read more information about its responsibilities and structure, go to [sectio
 - **State transitions:**
     - Update the court first term start time
 
-### 4.1.4. Heartbeat
+### 4.1.6. Heartbeat
 
 - **Actor:** Any entity incentivized to keep to Court term updated
 - **Inputs:**
@@ -117,7 +144,7 @@ To read more information about its responsibilities and structure, go to [sectio
     - Update the Court term
     - Create a new term object for each transitioned new term
 
-### 4.1.5. Ensure current term
+### 4.1.7. Ensure current term
 
 - **Actor:** Any entity incentivized to keep to Court term updated
 - **Inputs:** None
@@ -127,7 +154,7 @@ To read more information about its responsibilities and structure, go to [sectio
 - **State transitions:**
     - If necessary, update the Court term and create a new term object for each transitioned new term
 
-### 4.1.6. Ensure term randomness
+### 4.1.8. Ensure term randomness
 
 - **Actor:** Any entity incentivized to compute the term randomness for a certain term that has already been created
 - **Inputs:**
@@ -138,7 +165,7 @@ To read more information about its responsibilities and structure, go to [sectio
 - **State transitions:**
     - In case the term randomness has not been computed yet, set its randomness using the block hash of the following block when the term object was created
 
-### 4.1.7. Set automatic withdrawals
+### 4.1.9. Set automatic withdrawals
 
 - **Actor:** External entity holding funds in the Court protocol
 - **Inputs:**
@@ -148,7 +175,7 @@ To read more information about its responsibilities and structure, go to [sectio
 - **State transitions:**
     - Update the automatic withdrawals config of the sender
 
-### 4.1.8. Change funds governor
+### 4.1.10. Change funds governor
 
 - **Actor:** External entity in charge of maintaining the Court protocol
 - **Inputs:**
@@ -159,7 +186,7 @@ To read more information about its responsibilities and structure, go to [sectio
 - **State transitions:**
     - Update the funds governor address
 
-### 4.1.9. Change config governor
+### 4.1.11. Change config governor
 
 - **Actor:** External entity in charge of maintaining the Court protocol
 - **Inputs:**
@@ -170,7 +197,7 @@ To read more information about its responsibilities and structure, go to [sectio
 - **State transitions:**
     - Update the config governor address
 
-### 4.1.10. Change modules governor
+### 4.1.12. Change modules governor
 
 - **Actor:** External entity in charge of maintaining the Court protocol
 - **Inputs:**
@@ -181,7 +208,7 @@ To read more information about its responsibilities and structure, go to [sectio
 - **State transitions:**
     - Update the modules governor address
 
-### 4.1.11. Eject funds governor
+### 4.1.13. Eject funds governor
 
 - **Actor:** External entity in charge of maintaining the Court protocol
 - **Inputs:** None
@@ -190,7 +217,7 @@ To read more information about its responsibilities and structure, go to [sectio
 - **State transitions:**
     - Unset the funds governor address
 
-### 4.1.12. Eject modules governor
+### 4.1.14. Eject modules governor
 
 - **Actor:** External entity in charge of maintaining the Court protocol
 - **Inputs:** None
@@ -199,7 +226,7 @@ To read more information about its responsibilities and structure, go to [sectio
 - **State transitions:**
     - Unset the modules governor address
 
-### 4.1.13. Set module
+### 4.1.15. Set module
 
 - **Actor:** External entity in charge of maintaining the Court protocol
 - **Inputs:**
@@ -211,7 +238,7 @@ To read more information about its responsibilities and structure, go to [sectio
 - **State transitions:**
     - Set the module address for the corresponding module ID
 
-### 4.1.14. Set modules
+### 4.1.16. Set modules
 
 - **Actor:** External entity in charge of maintaining the Court protocol
 - **Inputs:**

--- a/docs/4-entry-points/2-court.md
+++ b/docs/4-entry-points/2-court.md
@@ -19,15 +19,14 @@ It is also in charge of executing the associated `Arbitrables` once the dispute 
 
 ### 4.2.2. Create dispute
 
-- **Actor:** Proposal Agreements instances, entities that need a dispute adjudicated
+- **Actor:** Controller
 - **Inputs:**
+    - **Subject:** Arbitrable instance creating the dispute
     - **Possible rulings:** Number of possible results for a dispute
     - **Metadata:** Optional metadata that can be used to provide additional information on the dispute to be created
-- **Authentication:** Open. Implicitly, only smart contracts that are up to date on their subscriptions in the `Subscription` module and that have open an ERC20 allowance with an amount of at least the dispute fee to the `Court` module can call this function
+- **Authentication:** Only the controller is allowed to call this function
 - **Pre-flight checks:**
     - Ensure that the Court term is up-to-date. Otherwise, perform a heartbeat before continuing the execution.
-    - Ensure that the msg.sender supports the `IArbitrable` interface
-    - Ensure that the subject is up to date on its subscription fees
     - Ensure that the number of possible rulings is within some reasonable bounds (hardcoded as constants)
 - **State transitions:**
     - Update current Court term if needed
@@ -102,19 +101,17 @@ It is also in charge of executing the associated `Arbitrables` once the dispute 
     - Calculate new round fees based on the Court configuration at the draft term of the dispute's first round
     - Pull the required appeal confirmation collateral, which includes the new round fees, from the sender to be deposited in the `Treasury` module, revert if the ERC20-transfer wasn't successful
 
-### 4.2.6. Execute ruling
+### 4.2.6. Compute ruling
 
-- **Actor:** External entity incentivized to execute the final ruling decided for a dispute. Alternatively, an altruistic entity to make sure the dispute is executed.
+- **Actor:** External entity incentivized to execute the final ruling decided for a dispute. Alternatively, an altruistic entity to make sure the dispute is ruled.
 - **Inputs:**
     - **Dispute ID:** Dispute identification number
 - **Authentication:** Open
 - **Pre-flight checks:**
     - Ensure a dispute object with that ID exists
-    - Ensure that the dispute has not been executed yet
     - Ensure that the dispute's last round adjudication phase has ended
 - **State transitions:**
     - Update the final ruling of the dispute object based on the ruling decided by the jurors during the current round or the ruling proposed by the appealer of the previous round in case there was one but wasn't confirmed.
-    - Execute the `Arbitrable` contract linked to the dispute based on the decided ruling
 
 ### 4.2.7. Settle penalties
 
@@ -142,7 +139,7 @@ It is also in charge of executing the associated `Arbitrables` once the dispute 
         - Update the adjudication round object to mark that all jurors' penalties were settled
     - In case all the jurors' penalties have been settled, and there was not even one juror voting in favor of the final ruling:
         - Ask the `JurorsRegistry` module to burn all the ANJ tokens that were collected during the adjudication round
-        - Return the adjudication round fees to the dispute creator or the appeal parties depending on whether the adjudication round was triggered by an external entity who created the dispute or due to a previous round that was appealed respectively.
+        - Return the adjudication round fees to the dispute creator or the appeal parties depending on whether the adjudication round was triggered by the `Arbitrable` instance who created the dispute or due to a previous round that was appealed respectively.
 
 ### 4.2.8. Settle reward
 

--- a/docs/5-data-structures/2-court.md
+++ b/docs/5-data-structures/2-court.md
@@ -9,7 +9,7 @@ The dispute object includes the following fields:
 - **Subject:** Arbitrable instance associated to a dispute
 - **Possible rulings:** Number of possible rulings jurors can vote for each dispute
 - **Final ruling:** Winning ruling of a dispute
-- **Dispute state:** State of a dispute: pre-draft, adjudicating, or executed
+- **Dispute state:** State of a dispute: pre-draft, adjudicating, or ruled
 - **Adjudication rounds:** List of adjudication rounds for each dispute
 
 ### 5.2.2. Adjudication round
@@ -18,7 +18,6 @@ The adjudication round object includes the following fields:
 
 - **Draft term ID:** Term from which the jurors of a round can be drafted
 - **Jurors number:** Number of jurors drafted for a round
-- **Triggered by:** Address that triggered a round
 - **Settled penalties:** Whether or not penalties have been settled for a round
 - **Juror fees:** Total amount of fees to be distributed between the winning jurors of a round
 - **Jurors:** List of jurors drafted for a round

--- a/docs/6-external-interface/1-controller.md
+++ b/docs/6-external-interface/1-controller.md
@@ -64,7 +64,26 @@ The following events are emitted by the `Controller`:
 
 The following functions are state getters provided by the `Controller`:
 
-#### 6.1.2.1. Config
+#### 6.1.2.1. Dispute fees
+
+- **Inputs:** None 
+- **Pre-flight checks:** None
+- **Outputs:**
+    **Recipient:** Address where the corresponding dispute fees must be transferred to
+    **Fee token:** ERC20 token used for the fees
+    **Fee amount:** Total amount of fees that must be allowed to the recipient
+
+#### 6.1.2.2. Subscription fees
+
+- **Inputs:** 
+    **Subscriber:** Address of the account paying the subscription fees for
+- **Pre-flight checks:** None
+- **Outputs:**
+    **Recipient:** Address where the corresponding subscriptions fees must be transferred to
+    **Fee token:** ERC20 token used for the subscription fees
+    **Fee amount:** Total amount of fees that must be allowed to the recipient
+
+#### 6.1.2.3. Config
 
 - **Inputs:**
     - **Term ID:** Identification number of the term querying the Court config of 
@@ -92,7 +111,7 @@ The following functions are state getters provided by the `Controller`:
         - **Appeal collateral factor:** Multiple of juror fees required to appeal a preliminary ruling
         - **Appeal confirm collateral factor:** Multiple of juror fees required to confirm appeal
 
-#### 6.1.2.2. Disputes config
+#### 6.1.2.4. Disputes config
 
 - **Inputs:**
     - **Term ID:** Identification number of the term querying the Court disputes config of
@@ -105,7 +124,7 @@ The following functions are state getters provided by the `Controller`:
     - **Settle fee:** Amount of tokens paid per round to cover the costs of slashing jurors
     - **First round jurors number:** Number of jurors drafted on first round
 
-#### 6.1.2.3. Drafts config
+#### 6.1.2.5. Drafts config
 
 - **Inputs:**
     - **Term ID:** Identification number of the term querying the Court drafts config of
@@ -115,7 +134,7 @@ The following functions are state getters provided by the `Controller`:
     - **Draft fee:** Amount of fee tokens per juror to cover the drafting cost
     - **Penalty pct:** Permyriad of min active tokens balance to be locked for each drafted juror (‱ - 1/10,000)
 
-#### 6.1.2.4. Minimum ANJ active balance
+#### 6.1.2.6. Minimum ANJ active balance
 
 - **Inputs:**
     - **Term ID:** Identification number of the term querying the Court min active balance of
@@ -123,42 +142,42 @@ The following functions are state getters provided by the `Controller`:
 - **Outputs:**
     - **Min active balance:** Minimum amount of juror tokens jurors have to activate to participate in the Court
 
-#### 6.1.2.5. Config change term ID
+#### 6.1.2.7. Config change term ID
 
 - **Inputs:** None 
 - **Pre-flight checks:** None
 - **Outputs:**
     - **Config change term ID:** Term identification number of the next scheduled config change
 
-#### 6.1.2.6. Term duration
+#### 6.1.2.8. Term duration
 
 - **Inputs:** None 
 - **Pre-flight checks:** None
 - **Outputs:**
     - **Term duration:** Duration in seconds of the Court term
 
-#### 6.1.2.7. Last ensured term ID
+#### 6.1.2.9. Last ensured term ID
 
 - **Inputs:** None 
 - **Pre-flight checks:** None
 - **Outputs:**
     - **Last ensured term ID:** Identification number of the last ensured term
 
-#### 6.1.2.8. Current term ID
+#### 6.1.2.10. Current term ID
 
 - **Inputs:** None 
 - **Pre-flight checks:** None
 - **Outputs:**
     - **Current term ID:** Identification number of the current term
 
-#### 6.1.2.9. Needed transitions
+#### 6.1.2.11. Needed transitions
 
 - **Inputs:** None 
 - **Pre-flight checks:** None  
 - **Outputs:**
     - **Needed transitions:** Number of terms the Court should transition to be up-to-date
     
-#### 6.1.2.10. Term
+#### 6.1.2.12. Term
 
 - **Inputs:** 
     - **Term ID:** Identification number of the term being queried
@@ -168,7 +187,7 @@ The following functions are state getters provided by the `Controller`:
     - **Randomness BN:** Block number used for randomness in the requested term
     - **Randomness:** Randomness computed for the requested term
     
-#### 6.1.2.11. Term randomness
+#### 6.1.2.13. Term randomness
 
 - **Inputs:** 
     - **Term ID:** Identification number of the term being queried
@@ -177,7 +196,7 @@ The following functions are state getters provided by the `Controller`:
 - **Outputs:**
     - **Term randomness:** Randomness of the requested term
 
-#### 6.1.2.12. Are withdrawals allowed for
+#### 6.1.2.14. Are withdrawals allowed for
 
 - **Inputs:** 
     - **Address:** Address of the token holder querying if withdrawals are allowed for
@@ -185,28 +204,28 @@ The following functions are state getters provided by the `Controller`:
 - **Outputs:**
     - **Allowed:** True if the given holder accepts automatic withdrawals of their tokens, false otherwise
 
-#### 6.1.2.13. Funds governor
+#### 6.1.2.15. Funds governor
 
 - **Inputs:** None 
 - **Pre-flight checks:** None
 - **Outputs:**
     - **Funds governor:** Address of the funds governor
 
-#### 6.1.2.14. Config governor
+#### 6.1.2.16. Config governor
 
 - **Inputs:** None 
 - **Pre-flight checks:** None
 - **Outputs:**
     - **Config governor:** Address of the config governor
 
-#### 6.1.2.15. Modules governor
+#### 6.1.2.17. Modules governor
 
 - **Inputs:** None 
 - **Pre-flight checks:** None
 - **Outputs:**
     - **Modules governor:** Address of the modules governor
 
-#### 6.1.2.16. Module
+#### 6.1.2.18. Module
 
 - **Inputs:** None 
 - **Pre-flight checks:** 
@@ -214,35 +233,35 @@ The following functions are state getters provided by the `Controller`:
 - **Outputs:**
     - **Module address:** Address of the module queried
 
-#### 6.1.2.17. Court
+#### 6.1.2.19. Court
 
 - **Inputs:** None 
 - **Pre-flight checks:** None
 - **Outputs:**
     - **Court address:** Address of the `Court` module set
 
-#### 6.1.2.18. Jurors registry
+#### 6.1.2.20. Jurors registry
 
 - **Inputs:** None 
 - **Pre-flight checks:** None
 - **Outputs:**
     - **Jurors registry address:** Address of the `JurorsRegistry` module set
 
-#### 6.1.2.19. Voting
+#### 6.1.2.21. Voting
 
 - **Inputs:** None 
 - **Pre-flight checks:** None
 - **Outputs:**
     - **Voting address:** Address of the `Voting` module set
 
-#### 6.1.2.20. Subscriptions
+#### 6.1.2.22. Subscriptions
 
 - **Inputs:** None 
 - **Pre-flight checks:** None
 - **Outputs:**
     - **Subscriptions address:** Address of the `Subscriptions` module set
 
-#### 6.1.2.21. Treasury
+#### 6.1.2.23. Treasury
 
 - **Inputs:** None 
 - **Pre-flight checks:** None

--- a/docs/6-external-interface/2-court.md
+++ b/docs/6-external-interface/2-court.md
@@ -19,7 +19,7 @@ The following events are emitted by the `Court`:
 - **Name:** `DisputeStateChanged`
 - **Args:**
     - **Dispute ID:** Identification number of the dispute that has changed 
-    - **State:** New dispute state: pre-draft, adjudicating, or executed 
+    - **State:** New dispute state: pre-draft, adjudicating, or ruled 
 
 #### 6.2.1.3. Ruling appealed
 
@@ -38,11 +38,11 @@ The following events are emitted by the `Court`:
     - **Draft term ID:** Identification number of the term when the next round will be able to be drafted
     - **Jurors number:** Next round jurors number
     
-#### 6.2.1.5. Ruling executed
+#### 6.2.1.5. Ruling computed
 
-- **Name:** `RulingExecuted`
+- **Name:** `RulingComputed`
 - **Args:**
-    - **Dispute ID:** Identification number of the dispute being executed
+    - **Dispute ID:** Identification number of the dispute being ruled
     - **Ruling:** Final ruling decided for the dispute
 
 #### 6.2.1.6. Penalties settled
@@ -96,7 +96,7 @@ The following functions are state getters provided by the `Court`:
 - **Outputs:**
     - **Subject:** Arbitrable subject being disputed
     - **Possible rulings:** Number of possible rulings allowed for the drafted jurors to vote on the dispute
-    - **State:** Current state of the dispute being queried: pre-draft, adjudicating, or executed
+    - **State:** Current state of the dispute being queried: pre-draft, adjudicating, or ruled
     - **Final ruling:** The winning ruling in case the dispute is finished
     - **Last round ID:** Identification number of the last round created for the dispute
 
@@ -113,7 +113,6 @@ The following functions are state getters provided by the `Court`:
     - **Delayed terms:** Number of terms the given round was delayed based on its requested draft term id
     - **Jurors number:** Number of jurors requested for the round
     - **Selected jurors:** Number of jurors already selected for the requested round
-    - **Triggered by:** Address that triggered the requested round
     - **Settled penalties:** Whether or not penalties have been settled for the requested round
     - **Collected tokens:** Amount of juror tokens that were collected from slashed jurors for the requested round
     - **Coherent jurors:** Number of jurors that voted in favor of the final ruling in the requested round

--- a/test/court/court-appeal.js
+++ b/test/court/court-appeal.js
@@ -157,17 +157,14 @@ contract('Court', ([_, drafter, appealMaker, appealTaker, juror500, juror1000, j
                   })
 
                   it('does not modify the current round of the dispute', async () => {
-                    const { triggeredBy: previousTrigger } = await courtHelper.getRound(disputeId, roundId)
-
                     await court.createAppeal(disputeId, roundId, appealMakerRuling, { from: appealMaker })
 
-                    const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, triggeredBy, jurorFees, settledPenalties, collectedTokens } = await courtHelper.getRound(disputeId, roundId)
+                    const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, jurorFees, settledPenalties, collectedTokens } = await courtHelper.getRound(disputeId, roundId)
                     assertBn(draftTerm, draftTermId, 'current round draft term does not match')
                     assertBn(delayedTerms, 0, 'current round delay term does not match')
                     assertBn(roundJurorsNumber, DEFAULTS.firstRoundJurorsNumber, 'current round jurors number does not match')
                     assertBn(selectedJurors, DEFAULTS.firstRoundJurorsNumber, 'current round selected jurors number does not match')
                     assertBn(jurorFees, courtHelper.jurorFee.mul(bn(DEFAULTS.firstRoundJurorsNumber)), 'current round juror fees do not match')
-                    assert.equal(triggeredBy, previousTrigger, 'current round trigger does not match')
                     assert.equal(settledPenalties, false, 'current round penalties should not be settled')
                     assertBn(collectedTokens, 0, 'current round collected tokens should be zero')
                   })

--- a/test/court/court-confirm-appeal.js
+++ b/test/court/court-confirm-appeal.js
@@ -205,7 +205,7 @@ contract('Court', ([_, drafter, appealMaker, appealTaker, juror500, juror1000, j
                       it('creates a new round for the given dispute', async () => {
                         await court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker })
 
-                        const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, triggeredBy, settledPenalties, jurorFees, collectedTokens } = await courtHelper.getRound(disputeId, roundId + 1)
+                        const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, settledPenalties, jurorFees, collectedTokens } = await courtHelper.getRound(disputeId, roundId + 1)
 
                         const nextRoundStartTerm = await courtHelper.getNextRoundStartTerm(disputeId, roundId)
                         assertBn(draftTerm, nextRoundStartTerm, 'new round draft term does not match')
@@ -218,23 +218,21 @@ contract('Court', ([_, drafter, appealMaker, appealTaker, juror500, juror1000, j
                         assertBn(jurorFees, nextRoundJurorFees, 'new round juror fees do not match')
 
                         assertBn(selectedJurors, 0, 'new round selected jurors number does not match')
-                        assert.equal(triggeredBy, appealTaker, 'new round trigger does not match')
-                        assert.equal(settledPenalties, false, 'new round penalties should not be settled')
                         assertBn(collectedTokens, 0, 'new round collected tokens should be zero')
+                        assert.equal(settledPenalties, false, 'new round penalties should not be settled')
                       })
 
                       it('does not modify the current round of the dispute', async () => {
-                        const { draftTerm: previousDraftTerm, delayedTerms: previousDelayedTerms, roundJurorsNumber: previousJurorsNumber, jurorFees: previousJurorFees, triggeredBy: previousTriggeredBy } = await courtHelper.getRound(disputeId, roundId)
+                        const { draftTerm: previousDraftTerm, delayedTerms: previousDelayedTerms, roundJurorsNumber: previousJurorsNumber, jurorFees: previousJurorFees } = await courtHelper.getRound(disputeId, roundId)
 
                         await court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker })
 
-                        const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, jurorFees, triggeredBy, settledPenalties, collectedTokens } = await courtHelper.getRound(disputeId, roundId)
+                        const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, jurorFees, settledPenalties, collectedTokens } = await courtHelper.getRound(disputeId, roundId)
                         assertBn(draftTerm, previousDraftTerm, 'current round draft term does not match')
                         assertBn(delayedTerms, previousDelayedTerms, 'current round delay term does not match')
                         assertBn(roundJurorsNumber, previousJurorsNumber, 'current round jurors number does not match')
                         assertBn(selectedJurors, previousJurorsNumber, 'current round selected jurors number does not match')
                         assertBn(jurorFees, previousJurorFees, 'current round juror fees do not match')
-                        assert.equal(triggeredBy, previousTriggeredBy, 'current round trigger does not match')
                         assert.equal(settledPenalties, false, 'current round penalties should not be settled')
                         assertBn(collectedTokens, 0, 'current round collected tokens should be zero')
                       })

--- a/test/court/court-disputes.js
+++ b/test/court/court-disputes.js
@@ -31,8 +31,8 @@ contract('Court', () => {
   })
 
   beforeEach('mock arbitrable instance', async () => {
-    arbitrable = await Arbitrable.new(court.address)
-    await courtHelper.subscriptions.setUpToDate(true)
+    arbitrable = await Arbitrable.new(courtHelper.controller.address)
+    await courtHelper.subscriptions.mockUpToDate(true)
     const { disputeFees } = await courtHelper.getDisputeFees()
     await courtHelper.mintFeeTokens(arbitrable.address, disputeFees)
   })
@@ -72,14 +72,13 @@ contract('Court', () => {
                 await courtHelper.setTerm(draftTermId - 1)
                 await arbitrable.createDispute(possibleRulings, metadata)
 
-                const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, jurorFees, triggeredBy, settledPenalties, collectedTokens } = await courtHelper.getRound(0, 0)
+                const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, jurorFees, settledPenalties, collectedTokens } = await courtHelper.getRound(0, 0)
 
                 assertBn(draftTerm, draftTermId, 'round draft term does not match')
                 assertBn(delayedTerms, 0, 'round delay term does not match')
                 assertBn(roundJurorsNumber, firstRoundJurorsNumber, 'round jurors number does not match')
                 assertBn(selectedJurors, 0, 'round selected jurors number does not match')
                 assertBn(jurorFees, courtHelper.jurorFee.mul(bn(firstRoundJurorsNumber)), 'round juror fees do not match')
-                assert.equal(triggeredBy, arbitrable.address, 'round trigger does not match')
                 assert.equal(settledPenalties, false, 'round penalties should not be settled')
                 assertBn(collectedTokens, 0, 'round collected tokens should be zero')
               })
@@ -166,7 +165,7 @@ contract('Court', () => {
 
       context('when the sender is outdated with the subscriptions', () => {
         beforeEach('expire subscriptions', async () => {
-          await courtHelper.subscriptions.setUpToDate(false)
+          await courtHelper.subscriptions.mockUpToDate(false)
         })
 
         it('reverts', async () => {
@@ -179,7 +178,7 @@ contract('Court', () => {
       let fakeArbitrable
 
       beforeEach('mock non arbitrable', async () => {
-        fakeArbitrable = await FakeArbitrable.new(court.address)
+        fakeArbitrable = await FakeArbitrable.new(courtHelper.controller.address)
       })
 
       it('reverts', async () => {
@@ -231,14 +230,13 @@ contract('Court', () => {
 
       context('when the given round is valid', async () => {
         it('returns the requested round', async () => {
-          const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, jurorFees, triggeredBy, settledPenalties, collectedTokens } = await courtHelper.getRound(0, 0)
+          const { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, jurorFees, settledPenalties, collectedTokens } = await courtHelper.getRound(0, 0)
 
           assertBn(draftTerm, draftTermId, 'round draft term does not match')
           assertBn(delayedTerms, 0, 'round delay term does not match')
           assertBn(roundJurorsNumber, firstRoundJurorsNumber, 'round jurors number does not match')
           assertBn(selectedJurors, 0, 'round selected jurors number does not match')
           assertBn(jurorFees, courtHelper.jurorFee.mul(bn(firstRoundJurorsNumber)), 'round juror fees do not match')
-          assert.equal(triggeredBy, arbitrable.address, 'round trigger does not match')
           assert.equal(settledPenalties, false, 'round penalties should not be settled')
           assertBn(collectedTokens, 0, 'round collected tokens should be zero')
         })

--- a/test/court/court-gas.js
+++ b/test/court/court-gas.js
@@ -42,8 +42,8 @@ contract('Court', ([_, sender, drafter, appealMaker, appealTaker, juror500, juro
 
       beforeEach('create arbitrable and approve fee amount', async () => {
         await courtHelper.setTerm(1)
-        arbitrable = await Arbitrable.new(court.address)
-        await courtHelper.subscriptions.setUpToDate(true)
+        arbitrable = await Arbitrable.new(controller.address)
+        await courtHelper.subscriptions.mockUpToDate(true)
         const { disputeFees } = await courtHelper.getDisputeFees()
         await courtHelper.mintFeeTokens(arbitrable.address, disputeFees)
       })
@@ -54,7 +54,7 @@ contract('Court', ([_, sender, drafter, appealMaker, appealTaker, juror500, juro
           assertBn(neededTransitions, 0, 'needed transitions does not match')
         })
 
-        itCostsAtMost('createDispute', 251e3, () => arbitrable.createDispute(2, '0x', { from: sender }))
+        itCostsAtMost('createDispute', 239e3, () => arbitrable.createDispute(2, '0x', { from: sender }))
       })
 
       context('when the current term is outdated by one term', () => {
@@ -64,7 +64,7 @@ contract('Court', ([_, sender, drafter, appealMaker, appealTaker, juror500, juro
           assertBn(neededTransitions, 1, 'needed transitions does not match')
         })
 
-        itCostsAtMost('createDispute', 307e3, () => arbitrable.createDispute(2, '0x', { from: sender }))
+        itCostsAtMost('createDispute', 295e3, () => arbitrable.createDispute(2, '0x', { from: sender }))
       })
     })
 
@@ -233,7 +233,7 @@ contract('Court', ([_, sender, drafter, appealMaker, appealTaker, juror500, juro
           assertBn(neededTransitions, 0, 'needed transitions does not match')
         })
 
-        itCostsAtMost('confirmAppeal', 179e3, () => court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker }))
+        itCostsAtMost('confirmAppeal', 159e3, () => court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker }))
       })
 
       context('when the current term is outdated by one term', () => {
@@ -243,7 +243,7 @@ contract('Court', ([_, sender, drafter, appealMaker, appealTaker, juror500, juro
           assertBn(neededTransitions, 1, 'needed transitions does not match')
         })
 
-        itCostsAtMost('confirmAppeal', 235e3, () => court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker }))
+        itCostsAtMost('confirmAppeal', 215e3, () => court.confirmAppeal(disputeId, roundId, appealTakerRuling, { from: appealTaker }))
       })
     })
 
@@ -270,7 +270,7 @@ contract('Court', ([_, sender, drafter, appealMaker, appealTaker, juror500, juro
           assertBn(neededTransitions, 0, 'needed transitions does not match')
         })
 
-        itCostsAtMost('executeRuling', 68e3, () => court.executeRuling(disputeId))
+        itCostsAtMost('executeRuling', 70e3, () => controller.executeRuling(disputeId))
       })
 
       context('when the current term is outdated by one term', () => {
@@ -280,7 +280,7 @@ contract('Court', ([_, sender, drafter, appealMaker, appealTaker, juror500, juro
           assertBn(neededTransitions, 1, 'needed transitions does not match')
         })
 
-        itCostsAtMost('executeRuling', 124e3, () => court.executeRuling(disputeId))
+        itCostsAtMost('executeRuling', 126e3, () => controller.executeRuling(disputeId))
       })
     })
 
@@ -320,7 +320,7 @@ contract('Court', ([_, sender, drafter, appealMaker, appealTaker, juror500, juro
           assertBn(neededTransitions, 1, 'needed transitions does not match')
         })
 
-        itCostsAtMost('settlePenalties', 253e3, () => court.settlePenalties(disputeId, roundId, 0))
+        itCostsAtMost('settlePenalties', 254e3, () => court.settlePenalties(disputeId, roundId, 0))
       })
     })
 

--- a/test/court/court-gas.js
+++ b/test/court/court-gas.js
@@ -280,7 +280,7 @@ contract('Court', ([_, sender, drafter, appealMaker, appealTaker, juror500, juro
           assertBn(neededTransitions, 1, 'needed transitions does not match')
         })
 
-        itCostsAtMost('executeRuling', 126e3, () => controller.executeRuling(disputeId))
+        itCostsAtMost('executeRuling', 127e3, () => controller.executeRuling(disputeId))
       })
     })
 

--- a/test/helpers/utils/events.js
+++ b/test/helpers/utils/events.js
@@ -1,5 +1,5 @@
 const ARBITRABLE_EVENTS = {
-  COURT_RULING: 'CourtRuling'
+  RULED: 'Ruled'
 }
 
 const COURT_EVENTS = {
@@ -7,7 +7,7 @@ const COURT_EVENTS = {
   NEW_DISPUTE: 'NewDispute',
   RULING_APPEALED: 'RulingAppealed',
   RULING_APPEAL_CONFIRMED: 'RulingAppealConfirmed',
-  RULING_EXECUTED: 'RulingExecuted',
+  RULING_COMPUTED: 'RulingComputed',
   PENALTIES_SETTLED: 'PenaltiesSettled',
   REWARD_SETTLED: 'RewardSettled',
   APPEAL_DEPOSIT_SETTLED: 'AppealDepositSettled',

--- a/test/helpers/wrappers/controller.js
+++ b/test/helpers/wrappers/controller.js
@@ -182,6 +182,7 @@ module.exports = (web3, artifacts) => {
           this.feeToken.address,
           this.subscriptionFeeAmount,
           this.subscriptionPrePaymentPeriods,
+          this.subscriptionResumePrePaidPeriods,
           this.subscriptionLatePaymentPenaltyPct,
           this.subscriptionGovernorSharePct
         )

--- a/test/helpers/wrappers/court.js
+++ b/test/helpers/wrappers/court.js
@@ -10,7 +10,7 @@ const PCT_BASE = bn(10000)
 const DISPUTE_STATES = {
   PRE_DRAFT: bn(0),
   ADJUDICATING: bn(1),
-  EXECUTED: bn(2)
+  RULED: bn(2)
 }
 
 const ROUND_STATES = {
@@ -38,8 +38,8 @@ module.exports = (web3, artifacts) => {
     }
 
     async getRound(disputeId, roundId) {
-      const { draftTerm, delayedTerms, jurorsNumber: roundJurorsNumber, selectedJurors, triggeredBy, settledPenalties, jurorFees, collectedTokens, coherentJurors, state: roundState } = await this.court.getRound(disputeId, roundId)
-      return { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, triggeredBy, settledPenalties, jurorFees, collectedTokens, coherentJurors, roundState }
+      const { draftTerm, delayedTerms, jurorsNumber: roundJurorsNumber, selectedJurors, settledPenalties, jurorFees, collectedTokens, coherentJurors, state: roundState } = await this.court.getRound(disputeId, roundId)
+      return { draftTerm, delayedTerms, roundJurorsNumber, selectedJurors, settledPenalties, jurorFees, collectedTokens, coherentJurors, roundState }
     }
 
     async getAppeal(disputeId, roundId) {
@@ -146,8 +146,8 @@ module.exports = (web3, artifacts) => {
       await this.setTerm(draftTermId - 1)
 
       // create an arbitrable if no one was given, and mock subscriptions
-      if (!arbitrable) arbitrable = await this.artifacts.require('ArbitrableMock').new(this.court.address)
-      await this.subscriptions.setUpToDate(true)
+      if (!arbitrable) arbitrable = await this.artifacts.require('ArbitrableMock').new(this.controller.address)
+      await this.subscriptions.mockUpToDate(true)
 
       // mint fee tokens for the arbitrable instance
       const { disputeFees } = await this.getDisputeFees()


### PR DESCRIPTION
*This is the third of a 4-series PRs, following https://github.com/aragon/aragon-court/pull/214*

This PR aims to provide support for the `IDisputeResolutionProtocol` required by the `ProposalAgreement` spec, implemented at a `Controller` level. Note that some changes were needed to be allowed to guarantee a single entry-point for users. 